### PR TITLE
Build Frontend in the Deployment Process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,8 @@ jobs:
     environment: Dev
     steps:
       - uses: actions/checkout@v2
-
+      - Build Frontend
+        cd ApplyToBecomeInternal/ApplyToBecomeInternal; npm install; npm run build
       - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,11 @@ jobs:
     environment: Dev
     steps:
       - uses: actions/checkout@v2
-      - Build Frontend
-        cd ApplyToBecomeInternal/ApplyToBecomeInternal; npm install; npm run build
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+            with: node-version: '14.x'
+      - name: Build Frontend
+        run: cd ApplyToBecomeInternal/ApplyToBecomeInternal; npm install; npm run build
       - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/package.json
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/package.json
@@ -2,10 +2,10 @@
   "name": "applytobecomeinternal",
   "version": "0.0.1",
   "description": "",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build-css": "sass wwwroot/css/"
-  },
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"build": "gulp build-fe"
+	},
   "author": "DfE",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Reference the existing [gulp file](https://github.com/DFE-Digital/a2b-internal/blob/master/ApplyToBecomeInternal/ApplyToBecomeInternal/gulpfile.js) created by @Robware and run it as a script in package.json

Update the deploy.yml file with a new step to navigate into the ApplyToBecome project, install npm and then run the build script.