### PR TITLE
Add Rationale summary page

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecome.Data/Models/Project.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data/Models/Project.cs
@@ -13,5 +13,6 @@ namespace ApplyToBecome.Data.Models
 		public DateTime? AssignedDate { get; set; }
 		public ProjectPhase Phase { get; set; }
 		public IEnumerable<DocumentDetails> ProjectDocuments { get; set; }
+		public Rationale Rationale { get; set; }
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecome.Data/Models/Rationale.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data/Models/Rationale.cs
@@ -2,7 +2,7 @@ namespace ApplyToBecome.Data.Models
 {
 	public class Rationale
 	{
-		public string ProjectRationale { get; set; }
-		public string TrustRationale { get; set; }
+		public string RationaleForProject { get; set; }
+		public string RationaleForTrust { get; set; }
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecome.Data/Models/Rationale.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data/Models/Rationale.cs
@@ -1,0 +1,8 @@
+namespace ApplyToBecome.Data.Models
+{
+	public class Rationale
+	{
+		public string ProjectRationale { get; set; }
+		public string TrustRationale { get; set; }
+	}
+}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ProjectViewModelTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ProjectViewModelTests.cs
@@ -42,8 +42,8 @@ namespace ApplyToBecomeInternal.Tests.Models
 				},
 				Rationale = new Rationale
 				{
-					ProjectRationale = "Rationale for the project",
-					TrustRationale = "Rationale for the trust"
+					RationaleForProject = "Rationale for the project",
+					RationaleForTrust = "Rationale for the trust"
 				}
 			};
 
@@ -57,8 +57,8 @@ namespace ApplyToBecomeInternal.Tests.Models
 			viewModel.AssignedDate.Should().Be("02 April 2021");
 			viewModel.Phase.Should().Be("Pre HTB");
 			viewModel.ProjectDocuments.Should().HaveCount(3);
-			viewModel.ProjectRationale.Should().Be("Rationale for the project");
-			viewModel.TrustRationale.Should().Be("Rationale for the trust");
+			viewModel.RationaleForProject.Should().Be("Rationale for the project");
+			viewModel.RationaleForTrust.Should().Be("Rationale for the trust");
 		}
 
 		[Fact]
@@ -72,7 +72,7 @@ namespace ApplyToBecomeInternal.Tests.Models
 				ApplicationReceivedDate = new DateTime(2020, 12, 12),
 				AssignedDate = new DateTime(2021, 04, 02),
 				Phase = ProjectPhase.PostHTB,
-				Rationale = new Rationale {ProjectRationale = "Rationale for the project", TrustRationale = "Rationale for the trust"}
+				Rationale = new Rationale {RationaleForProject = "Rationale for the project", RationaleForTrust = "Rationale for the trust"}
 			};
 
 			var viewModel = new ProjectViewModel(project);

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ProjectViewModelTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ProjectViewModelTests.cs
@@ -71,7 +71,8 @@ namespace ApplyToBecomeInternal.Tests.Models
 				Trust = new Trust {Name = "Trust Name"},
 				ApplicationReceivedDate = new DateTime(2020, 12, 12),
 				AssignedDate = new DateTime(2021, 04, 02),
-				Phase = ProjectPhase.PostHTB
+				Phase = ProjectPhase.PostHTB,
+				Rationale = new Rationale {ProjectRationale = "Rationale for the project", TrustRationale = "Rationale for the trust"}
 			};
 
 			var viewModel = new ProjectViewModel(project);

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ProjectViewModelTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ProjectViewModelTests.cs
@@ -39,19 +39,26 @@ namespace ApplyToBecomeInternal.Tests.Models
 						Type = "Word document",
 						Size = "854kb"
 					}
+				},
+				Rationale = new Rationale
+				{
+					ProjectRationale = "Rationale for the project",
+					TrustRationale = "Rationale for the trust"
 				}
 			};
-			
+
 			var viewModel = new ProjectViewModel(project);
 			viewModel.Id.Should().Be("1");
 			viewModel.TrustName.Should().Be("Trust Name");
 			viewModel.SchoolName.Should().Be("School Name");
 			viewModel.SchoolURN.Should().Be("URN");
-			viewModel.LocalAuthority.Should().Be("Local Authority"); 
+			viewModel.LocalAuthority.Should().Be("Local Authority");
 			viewModel.ApplicationReceivedDate.Should().Be("12 December 2020");
 			viewModel.AssignedDate.Should().Be("02 April 2021");
 			viewModel.Phase.Should().Be("Pre HTB");
 			viewModel.ProjectDocuments.Should().HaveCount(3);
+			viewModel.ProjectRationale.Should().Be("Rationale for the project");
+			viewModel.TrustRationale.Should().Be("Rationale for the trust");
 		}
 
 		[Fact]

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/Links.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/Links.cs
@@ -24,6 +24,11 @@
 			public static LinkItem PreviewHTBTemplate = new LinkItem { BackText = "Back", Page = "/TaskList/PreviewHTBTemplate" };
 			public static LinkItem GenerateHTBTemplate = new LinkItem { BackText = "Back", Page = "/TaskList/GenerateHTBTemplate" };
 		}
+
+		public static class Rationale
+		{
+			public static LinkItem Index = new LinkItem { BackText = "Back", Page = "/TaskList/Rationale" };
+		}
 	}
 
 	public class LinkItem

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/Links.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/Links.cs
@@ -20,9 +20,14 @@
 
 		public static class TaskList
 		{
-			public static LinkItem Index = new LinkItem { BackText = "Back", Page = "/TaskList/Index" };
+			public static LinkItem Index = new LinkItem { BackText = "Back to task list", Page = "/TaskList/Index" };
 			public static LinkItem PreviewHTBTemplate = new LinkItem { BackText = "Back", Page = "/TaskList/PreviewHTBTemplate" };
 			public static LinkItem GenerateHTBTemplate = new LinkItem { BackText = "Back", Page = "/TaskList/GenerateHTBTemplate" };
+		}
+
+		public static class SchoolApplicationForm
+		{
+			public static LinkItem Index = new LinkItem { BackText = "Back", Page = "/ApplicationForm/Index" };
 		}
 
 		public static class Rationale

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Index.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Index.cshtml
@@ -66,7 +66,7 @@
 			</li>
 			<li class="app-task-list__item">
 				<span class="app-task-list__task-name">
-					<a class="govuk-link" href="#" aria-describedby="rationale-status">
+					<a class="govuk-link" asp-page="@Links.Rationale.Index.Page" asp-route-id="@Model.Project.Id" aria-describedby="rationale-status">
 						Rationale
 					</a>
 				</span>

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
@@ -1,16 +1,54 @@
 @page "/task-list/{id:int}/rationale"
 @model ApplyToBecomeInternal.Pages.TaskList.IndexModel
 
-<span class="govuk-caption-l">@Model.Project.SchoolName</span>
-<h1 class="govuk-heading-l">
-	Confirm project and trust rationale
-</h1>
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-full">
+	    @section BeforeMain
+        {
+            <a asp-page="@Links.TaskList.Index.Page" asp-route-id="@Model.Project.Id" class="govuk-back-link">@Links.TaskList.Index.BackText</a>
+        }
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-full">
+				<span class="govuk-caption-l">@Model.Project.SchoolName</span>
+				<h1 class="govuk-heading-l">
+					Confirm project and trust rationale
+				</h1>
+				<div class="govuk-body">
+					<p>
+						This information is pre-populated from the
+						<a asp-page="@Links.SchoolApplicationForm.Index.Page" asp-route-id="@Model.Project.Id" target="_blank">school's application form (opens in a new tab)</a>.
+					</p>
+				</div>
+			</div>
+		</div>
+		<dl class="govuk-summary-list">
+			<div class="govuk-summary-list__row">
+		    <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
+		      Rationale for project
+		    </dt>
+		    <dd class="govuk-summary-list__value govuk-!-width-full">
+				@Model.Project.ProjectRationale
+			</dd>
+		    <dd class="govuk-summary-list__actions">
+		      <a class="govuk-link" href="">
+		        Change<span class="govuk-visually-hidden">project rationale</span>
+		      </a>
+		    </dd>
+		  </div>
 
-<p>
-	This information is pre-populated from the
-	@* sort this link *@
-	<a href="/related/application_newtab" target="_blank">school's application form (opens in a new tab)</a>.
-</p>
-
-
-
+		  <div class="govuk-summary-list__row">
+		    <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
+		      Rationale for the trust or sponsor
+		    </dt>
+		      <dd class="govuk-summary-list__value  govuk-!-width-two-thirds">
+		          @Model.Project.TrustRationale
+		      </dd>
+		    <dd class="govuk-summary-list__actions">
+		      <a class="govuk-link" href="">
+		        Change<span class="govuk-visually-hidden">sponsor rationale</span>
+		      </a>
+		    </dd>
+		  </div>
+		</dl>
+	</div>
+</div>

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
@@ -26,9 +26,17 @@
 		    <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
 		      Rationale for project
 		    </dt>
-		    <dd class="govuk-summary-list__value govuk-!-width-full">
-				@Model.Project.ProjectRationale
-			</dd>
+				<dd class="govuk-summary-list__value govuk-!-width-full">
+					@if (!string.IsNullOrEmpty(@Model.Project.ProjectRationale))
+					{
+						@Model.Project.ProjectRationale
+					}
+					else
+					{
+						<span class="empty">Empty</span>
+					}
+
+				</dd>
 		    <dd class="govuk-summary-list__actions">
 		      <a class="govuk-link" href="">
 		        Change<span class="govuk-visually-hidden">project rationale</span>
@@ -40,8 +48,15 @@
 		    <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
 		      Rationale for the trust or sponsor
 		    </dt>
-		      <dd class="govuk-summary-list__value  govuk-!-width-two-thirds">
-		          @Model.Project.TrustRationale
+		      <dd class="govuk-summary-list__value govuk-!-width-two-thirds">
+			      @if (!string.IsNullOrEmpty(@Model.Project.TrustRationale))
+			      {
+				      @Model.Project.TrustRationale
+			      }
+			      else
+			      {
+				      <span class="empty">Empty</span>
+			      }
 		      </dd>
 		    <dd class="govuk-summary-list__actions">
 		      <a class="govuk-link" href="">

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
@@ -27,9 +27,9 @@
 		      Rationale for project
 		    </dt>
 				<dd class="govuk-summary-list__value govuk-!-width-full">
-					@if (!string.IsNullOrEmpty(@Model.Project.ProjectRationale))
+					@if (!string.IsNullOrEmpty(@Model.Project.RationaleForProject))
 					{
-						@Model.Project.ProjectRationale
+						@Model.Project.RationaleForProject
 					}
 					else
 					{
@@ -49,9 +49,9 @@
 		      Rationale for the trust or sponsor
 		    </dt>
 		      <dd class="govuk-summary-list__value govuk-!-width-two-thirds">
-			      @if (!string.IsNullOrEmpty(@Model.Project.TrustRationale))
+			      @if (!string.IsNullOrEmpty(@Model.Project.RationaleForTrust))
 			      {
-				      @Model.Project.TrustRationale
+				      @Model.Project.RationaleForTrust
 			      }
 			      else
 			      {

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Rationale.cshtml
@@ -1,0 +1,16 @@
+@page "/task-list/{id:int}/rationale"
+@model ApplyToBecomeInternal.Pages.TaskList.IndexModel
+
+<span class="govuk-caption-l">@Model.Project.SchoolName</span>
+<h1 class="govuk-heading-l">
+	Confirm project and trust rationale
+</h1>
+
+<p>
+	This information is pre-populated from the
+	@* sort this link *@
+	<a href="/related/application_newtab" target="_blank">school's application form (opens in a new tab)</a>.
+</p>
+
+
+

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/ViewModels/ProjectViewModel.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/ViewModels/ProjectViewModel.cs
@@ -7,7 +7,7 @@ namespace ApplyToBecomeInternal.ViewModels
 {
 	public class ProjectViewModel
 	{
-		private readonly Dictionary<ProjectPhase, string> _projectPhaseText = new Dictionary<ProjectPhase, string> 
+		private readonly Dictionary<ProjectPhase, string> _projectPhaseText = new Dictionary<ProjectPhase, string>
 		{
 			{ProjectPhase.PreHTB, "Pre HTB"},
 			{ProjectPhase.PostHTB, "Post HTB"}
@@ -24,6 +24,8 @@ namespace ApplyToBecomeInternal.ViewModels
 			AssignedDate = FormatDate(project.AssignedDate);
 			Phase = _projectPhaseText[project.Phase];
 			ProjectDocuments = project.ProjectDocuments;
+			ProjectRationale = project.Rationale.ProjectRationale;
+			TrustRationale = project.Rationale.TrustRationale;
 		}
 
 
@@ -38,5 +40,7 @@ namespace ApplyToBecomeInternal.ViewModels
 		public string AssignedDate { get; }
 		public string Phase { get; }
 		public IEnumerable<DocumentDetails> ProjectDocuments { get; set; }
+		public string ProjectRationale { get; set; }
+		public string TrustRationale { get; set; }
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/ViewModels/ProjectViewModel.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/ViewModels/ProjectViewModel.cs
@@ -24,8 +24,8 @@ namespace ApplyToBecomeInternal.ViewModels
 			AssignedDate = FormatDate(project.AssignedDate);
 			Phase = _projectPhaseText[project.Phase];
 			ProjectDocuments = project.ProjectDocuments;
-			ProjectRationale = project.Rationale.ProjectRationale;
-			TrustRationale = project.Rationale.TrustRationale;
+			RationaleForProject = project.Rationale.RationaleForProject;
+			RationaleForTrust = project.Rationale.RationaleForTrust;
 		}
 
 
@@ -40,7 +40,7 @@ namespace ApplyToBecomeInternal.ViewModels
 		public string AssignedDate { get; }
 		public string Phase { get; }
 		public IEnumerable<DocumentDetails> ProjectDocuments { get; set; }
-		public string ProjectRationale { get; set; }
-		public string TrustRationale { get; set; }
+		public string RationaleForProject { get; set; }
+		public string RationaleForTrust { get; set; }
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/wwwroot/css/_task-list.scss
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/wwwroot/css/_task-list.scss
@@ -70,3 +70,26 @@
 		margin-bottom: 0;
 	}
 }
+
+.empty {
+  display: inline-block;
+  border: 2px solid;
+  outline-offset: -2px;
+  color: #505a5f;
+  background-color: #ffffff;
+  letter-spacing: 1px;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 14px;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding-top: 3px;
+  padding-right: 8px;
+  padding-bottom: 3px;
+  padding-left: 8px;
+  margin-right: 8px;
+}


### PR DESCRIPTION
- Add the Rationale summary page, and navigation to the page from the task list, and back.

- Display the pre-populated content for the Rationale for the project and the Rationale for the trust. If no pre-populated rationale content exists for either rationale page, an 'Empty' box is displayed, as per the prototype.

NB: I'll add integration tests for this, but creating the PR now for the sake of visibility and tickets that are somewhat dependent on this work.

<img width="1127" alt="Screenshot 2021-06-08 at 08 49 29" src="https://user-images.githubusercontent.com/40759410/121145223-a2cc0180-c836-11eb-9126-400ffd893cbd.png">
<img width="1044" alt="Screenshot 2021-06-08 at 08 49 54" src="https://user-images.githubusercontent.com/40759410/121145219-a19ad480-c836-11eb-8244-71e2a390bd07.png">



