### PR TITLE
Local authority tweaks

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/ConfirmLocalAuthorityInformationTemplateDatesIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/ConfirmLocalAuthorityInformationTemplateDatesIntegrationTests.cs
@@ -1,7 +1,9 @@
 ﻿using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using ApplyToBecomeInternal.Extensions;
+using ApplyToBecomeInternal.Tests.Customisations;
 using FluentAssertions;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,7 +11,10 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 {
 	public class ConfirmLocalAuthorityInformationTemplateDatesIntegrationTests : BaseIntegrationTests
 	{
-		public ConfirmLocalAuthorityInformationTemplateDatesIntegrationTests(IntegrationTestingWebApplicationFactory factory) : base(factory) { }
+		public ConfirmLocalAuthorityInformationTemplateDatesIntegrationTests(IntegrationTestingWebApplicationFactory factory) : base(factory)
+		{
+			_fixture.Customizations.Add(new RandomDateBuilder(DateTime.Now.AddMonths(-24), DateTime.Now.AddMonths(6)));
+		}
 
 		[Fact]
 		public async Task Should_be_in_progress_and_display_la_info_template_when_populated()
@@ -65,7 +70,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 		}
 
 		[Fact]
-		public async Task Should_navigate_between_task_list_and_confirm_la_info_template()
+		public async Task Should_navigate_between_task_list_and_confirm_la_info_template_when_navigated_from_task_list()
 		{
 			var project = AddGetProject();
 
@@ -77,6 +82,29 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 			await NavigateAsync("Back to task list");
 
 			Document.Url.Should().BeUrl($"/task-list/{project.Id}");
+		}
+
+		[Fact]
+		public async Task Should_navigate_between_la_info_template_and_confirm_la_info_template_when_navigated_from_la_info_template()
+		{
+			var project = AddGetProject();
+
+			AddPatchProjectMany(project, composer =>
+				composer
+					.With(r => r.LocalAuthorityInformationTemplateSentDate, project.LocalAuthorityInformationTemplateSentDate)
+					.With(r => r.LocalAuthorityInformationTemplateReturnedDate, project.LocalAuthorityInformationTemplateReturnedDate)
+					.With(r => r.LocalAuthorityInformationTemplateComments, project.LocalAuthorityInformationTemplateComments)
+					.With(r => r.LocalAuthorityInformationTemplateLink, project.LocalAuthorityInformationTemplateLink));
+
+			await OpenUrlAsync($"/task-list/{project.Id}/record-local-authority-information-template-dates");
+
+			await Document.QuerySelector<IHtmlFormElement>("form").SubmitAsync();
+
+			Document.Url.Should().BeUrl($"/task-list/{project.Id}/confirm-local-authority-information-template-dates");
+
+			await NavigateAsync("Back");
+
+			Document.Url.Should().BeUrl($"/task-list/{project.Id}/record-local-authority-information-template-dates");
 		}
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDatesIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDatesIntegrationTests.cs
@@ -63,7 +63,6 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 				.With(r => r.LocalAuthorityInformationTemplateComments)
 				.With(r => r.LocalAuthorityInformationTemplateLink));
 
-
 			await OpenUrlAsync($"/task-list/{project.Id}/confirm-local-authority-information-template-dates");
 			await NavigateAsync("Change", 0);
 
@@ -102,7 +101,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 			Document.QuerySelector<IHtmlInputElement>("#la-info-template-returned-date-day").Value.Should().Be(project.LocalAuthorityInformationTemplateReturnedDate.Value.Day.ToString());
 			Document.QuerySelector<IHtmlInputElement>("#la-info-template-returned-date-month").Value.Should().Be(project.LocalAuthorityInformationTemplateReturnedDate.Value.Month.ToString());
 			Document.QuerySelector<IHtmlInputElement>("#la-info-template-returned-date-year").Value.Should().Be(project.LocalAuthorityInformationTemplateReturnedDate.Value.Year.ToString());
-			Document.QuerySelector("#la-info-template-comments").TextContent.Should().Be(project.LocalAuthorityInformationTemplateComments);
+			Document.QuerySelector<IHtmlTextAreaElement>("#la-info-template-comments").Value.Should().Be(project.LocalAuthorityInformationTemplateComments);
 			Document.QuerySelector<IHtmlInputElement>("#la-info-template-sharepoint-link").Value.Should().Be(project.LocalAuthorityInformationTemplateLink);
 		}
 

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDatesIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDatesIntegrationTests.cs
@@ -128,5 +128,31 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 
 			Document.Url.Should().BeUrl($"/task-list/{project.Id}");
 		}
+
+		[Fact]
+		public async Task Should_set_dates_to_default_date_when_cleared()
+		{
+			var project = AddGetProject();
+
+			AddPatchProjectMany(project, composer =>
+				composer
+				.With(r => r.LocalAuthorityInformationTemplateSentDate, default(DateTime))
+				.With(r => r.LocalAuthorityInformationTemplateReturnedDate, default(DateTime))
+				.With(r => r.LocalAuthorityInformationTemplateComments, project.LocalAuthorityInformationTemplateComments)
+				.With(r => r.LocalAuthorityInformationTemplateLink, project.LocalAuthorityInformationTemplateLink));
+
+			await OpenUrlAsync($"/task-list/{project.Id}/record-local-authority-information-template-dates");
+
+			Document.QuerySelector<IHtmlInputElement>("#la-info-template-sent-date-day").Value = string.Empty;
+			Document.QuerySelector<IHtmlInputElement>("#la-info-template-sent-date-month").Value = string.Empty;
+			Document.QuerySelector<IHtmlInputElement>("#la-info-template-sent-date-year").Value = string.Empty;
+			Document.QuerySelector<IHtmlInputElement>("#la-info-template-returned-date-day").Value = string.Empty;
+			Document.QuerySelector<IHtmlInputElement>("#la-info-template-returned-date-month").Value = string.Empty;
+			Document.QuerySelector<IHtmlInputElement>("#la-info-template-returned-date-year").Value = string.Empty;
+
+			await Document.QuerySelector<IHtmlFormElement>("form").SubmitAsync();
+
+			Document.Url.Should().BeUrl($"/task-list/{project.Id}/confirm-local-authority-information-template-dates");
+		}
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDatesIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDatesIntegrationTests.cs
@@ -119,14 +119,14 @@ namespace ApplyToBecomeInternal.Tests.Pages.LocalAuthorityInformationTemplate
 		}
 
 		[Fact]
-		public async Task Should_navigate_back_to_confirm_la_info_template_from_la_info_template()
+		public async Task Should_navigate_back_to_task_list_from_la_info_template()
 		{
 			var project = AddGetProject();
 
 			await OpenUrlAsync($"/task-list/{project.Id}/record-local-authority-information-template-dates");
-			await NavigateAsync("Back");
+			await NavigateAsync("Back to task list");
 
-			Document.Url.Should().BeUrl($"/task-list/{project.Id}/confirm-local-authority-information-template-dates");
+			Document.Url.Should().BeUrl($"/task-list/{project.Id}");
 		}
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/DateInputModelBinder.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/DateInputModelBinder.cs
@@ -35,7 +35,15 @@ namespace ApplyToBecomeInternal.Models
 			{
 				if (modelType == typeof(DateTime?))
 				{
-					bindingContext.Result = ModelBindingResult.Success(null);
+					if (IsEmptyDate())
+					{
+						var date = default(DateTime);
+						bindingContext.Result = ModelBindingResult.Success(date);
+					}
+					else
+					{
+						bindingContext.Result = ModelBindingResult.Success(null);
+					}
 				}
 				else
 				{
@@ -58,13 +66,6 @@ namespace ApplyToBecomeInternal.Models
 			if (dayValid && monthValid && yearValid)
 			{
 				var date = new DateTime(year, month, day);
-				bindingContext.Result = ModelBindingResult.Success(date);
-			}
-			else if (dayValueProviderResult.FirstValue == string.Empty
-			         && monthValueProviderResult.FirstValue == string.Empty
-			         && yearValueProviderResult.FirstValue == string.Empty)
-			{
-				var date = default(DateTime);
 				bindingContext.Result = ModelBindingResult.Success(date);
 			}
 			else
@@ -208,6 +209,13 @@ namespace ApplyToBecomeInternal.Models
 					|| dayValueProviderResult == ValueProviderResult.None
 					&& monthValueProviderResult == ValueProviderResult.None
 					&& yearValueProviderResult == ValueProviderResult.None;
+			}
+
+			bool IsEmptyDate()
+			{
+				return dayValueProviderResult.FirstValue == string.Empty
+				       && monthValueProviderResult.FirstValue == string.Empty
+				       && yearValueProviderResult.FirstValue == string.Empty;
 			}
 		}
 	}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/DateInputModelBinder.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Models/DateInputModelBinder.cs
@@ -27,8 +27,8 @@ namespace ApplyToBecomeInternal.Models
 			var monthValueProviderResult  = bindingContext.ValueProvider.GetValue(monthModelName);
 			var yearValueProviderResult  = bindingContext.ValueProvider.GetValue(yearModelName);
 
-			if (dayValueProviderResult  == ValueProviderResult.None 
-				&& monthValueProviderResult  == ValueProviderResult.None 
+			if (dayValueProviderResult  == ValueProviderResult.None
+				&& monthValueProviderResult  == ValueProviderResult.None
 				&& yearValueProviderResult  == ValueProviderResult.None)
 			{
 				if (modelType == typeof(DateTime?))
@@ -50,6 +50,13 @@ namespace ApplyToBecomeInternal.Models
 			if (TryParseYear() && TryParseMonth() && TryParseDay())
 			{
 				var date = new DateTime(year, month, day);
+				bindingContext.Result = ModelBindingResult.Success(date);
+			}
+			else if (dayValueProviderResult.FirstValue == string.Empty
+			         && monthValueProviderResult.FirstValue == string.Empty
+			         && yearValueProviderResult.FirstValue == string.Empty)
+			{
+				var date = default(DateTime);
 				bindingContext.Result = ModelBindingResult.Success(date);
 			}
 			else

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/BaseAcademyConversionProjectPageModel.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/BaseAcademyConversionProjectPageModel.cs
@@ -19,6 +19,7 @@ namespace ApplyToBecomeInternal.Pages
 
 		public virtual async Task<IActionResult> OnGetAsync(int id)
 		{
+			ViewData["Referer"] = HttpContext.Request.Headers["Referer"];
 			return await SetProject(id);
 		}
 

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/LocalAuthorityInformationTemplate/ConfirmLocalAuthorityInformationTemplateDates.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/LocalAuthorityInformationTemplate/ConfirmLocalAuthorityInformationTemplateDates.cshtml
@@ -6,9 +6,9 @@
 }
 @section BeforeMain
 {
-	@if (ViewData["Referer"].ToString()?.Contains("local-authority-information") == true)
+	@if (ViewData["Referer"]?.ToString()?.Contains("local-authority-information") == true)
     {
-	    <a back-link-for="@Links.LocalAuthorityInformationTemplateSection.RecordLocalAuthorityInformationTemplateDates"></a>
+		<a back-link-for="@Links.LocalAuthorityInformationTemplateSection.RecordLocalAuthorityInformationTemplateDates"></a>
     }
 	else
     {

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/LocalAuthorityInformationTemplate/ConfirmLocalAuthorityInformationTemplateDates.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/LocalAuthorityInformationTemplate/ConfirmLocalAuthorityInformationTemplateDates.cshtml
@@ -5,7 +5,14 @@
 }
 @section BeforeMain
 {
-	<a back-link-for="@Links.TaskList.Index"></a>
+	@if (ViewData["Referer"].ToString()?.Contains("local-authority-information") == true)
+    {
+	    <a back-link-for="@Links.LocalAuthorityInformationTemplateSection.RecordLocalAuthorityInformationTemplateDates"></a>
+    }
+	else
+    {
+	    <a back-link-for="@Links.TaskList.Index"></a>
+    }
 }
 
 @if (Model.ShowError)

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDates.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/LocalAuthorityInformationTemplate/RecordLocalAuthorityInformationTemplateDates.cshtml
@@ -5,7 +5,7 @@
 }
 @section BeforeMain
 {
-	<a back-link-for="@Links.LocalAuthorityInformationTemplateSection.ConfirmLocalAuthorityInformationTemplateDates"></a>
+	<a back-link-for="@Links.TaskList.Index"></a>
 }
 
 @if (Model.ShowError)
@@ -45,9 +45,9 @@
 				<label class="govuk-label govuk-fieldset__legend--s" for="la-info-template-comments">
 					Comments (optional)
 				</label>
-				<textarea class="govuk-textarea" 
-						  id="la-info-template-comments" 
-						  name="la-info-template-comments" 
+				<textarea class="govuk-textarea"
+						  id="la-info-template-comments"
+						  name="la-info-template-comments"
 						  asp-for="Project.LocalAuthorityInformationTemplateComments"
 						  rows="5"></textarea>
 			</div>
@@ -55,9 +55,9 @@
 				<label class="govuk-label govuk-fieldset__legend--s" for="la-info-template-sharepoint-link">
 					Add a link to where you have stored the template in Sharepoint
 				</label>
-				<input class="govuk-input" 
-					   id="la-info-template-sharepoint-link" 
-					   name="la-info-template-sharepoint-link" 
+				<input class="govuk-input"
+					   id="la-info-template-sharepoint-link"
+					   name="la-info-template-sharepoint-link"
 					   asp-for="Project.LocalAuthorityInformationTemplateLink"
 					   type="text">
 			</div>


### PR DESCRIPTION
- If date is cleared, send as default date in the update request - otherwise it will be sent as null and won't get updated in the backend as per the patching strategy.
- Update back logic on `Confirm local authority information template dates` page - go back to `Record dates for the local authority information template` and display link as `Back` if navigated from there, otherwise go back to `Task list` and display as `Back to task list`
- Update back link on `Record dates for the local authority information template` so that it displays as `Back to task list` and always goes back to Task list.

NB:
Desptie GH rendering the diff for some files as whole file changes, the changes of note are actually:

`DateInputModelBinder.cs`: lines 38-42
`ConfirmLocalAuthorityInformationTemplateDatesIntegrationTests`: lines 88 - 107
`BaseAcademyConversionProjectPageModel.cs`: line 22