### PR TITLE
Update branch name in GHA deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   deploy_to_dev:


### PR DESCRIPTION
This is needed because the default branch was renamed from master -> main.