### PR TITLE
Decrease margin between titles and content on application form

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/ApplicationForm/Index.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/ApplicationForm/Index.cshtml
@@ -9,27 +9,30 @@
 	<a asp-page="@Links.ProjectList.Index.Page" class="govuk-back-link">@Links.ProjectList.Index.BackText</a>
 }
 
-<partial name="_ProjectHeader" model="Model.Project" />
+<partial name="_ProjectHeader" model="Model.Project"/>
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-full">
 		@foreach (var formSection in Model.Sections)
 		{
-			<h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">@formSection.Heading</h2>
-			<dl class="govuk-summary-list">
-				@foreach (var sectionField in formSection.Fields)
-				{
-					<partial name="_ApplicationFormField" model="sectionField" />
-				}
-			</dl>
+			<h2 class="govuk-heading-l govuk-!-margin-bottom-2 govuk-!-font-size-36">@formSection.Heading</h2>
+			@if (formSection.Fields.Any())
+			{
+				<dl class="govuk-summary-list">
+					@foreach (var sectionField in formSection.Fields)
+					{
+						<partial name="_ApplicationFormField" model="sectionField"/>
+					}
+				</dl>
+			}
 
 			@foreach (var subSection in formSection.SubSections)
 			{
-				<h3 class="govuk-heading-m govuk-!-margin-bottom govuk-!-font-size-24">@subSection.Heading</h3>
+				<h3 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-font-size-24">@subSection.Heading</h3>
 				<dl class="govuk-summary-list">
 					@foreach (var sectionField in subSection.Fields)
 					{
-						<partial name="_ApplicationFormField" model="sectionField" />
+						<partial name="_ApplicationFormField" model="sectionField"/>
 					}
 				</dl>
 			}


### PR DESCRIPTION
- Hides empty form field sections where there's no information
- Sets the margin override correctly on headings to keep them closer to the content they're for