### PR TITLE
Ensure wiremock server is reset after every test

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/IntegrationTestingWebApplicationFactory.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/IntegrationTestingWebApplicationFactory.cs
@@ -17,9 +17,6 @@ using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
-using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace ApplyToBecomeInternal.Tests
 {

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/BaseIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/BaseIntegrationTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace ApplyToBecomeInternal.Tests.Pages
 {
-	public abstract partial class BaseIntegrationTests : IClassFixture<IntegrationTestingWebApplicationFactory>
+	public abstract partial class BaseIntegrationTests : IClassFixture<IntegrationTestingWebApplicationFactory>, IDisposable
 	{
 		private readonly IntegrationTestingWebApplicationFactory _factory;
 		private readonly IBrowsingContext _browsingContext;
@@ -36,10 +36,10 @@ namespace ApplyToBecomeInternal.Tests.Pages
 		{
 			var anchors = Document.QuerySelectorAll("a");
 			var link = (index == null
-				? anchors.Single(a => a.TextContent.Contains(linkText))
-				: anchors.Where(a => a.TextContent.Contains(linkText)).ElementAt(index.Value))
+					? anchors.Single(a => a.TextContent.Contains(linkText))
+					: anchors.Where(a => a.TextContent.Contains(linkText)).ElementAt(index.Value))
 				as IHtmlAnchorElement;
-			
+
 			return await link.NavigateAsync();
 		}
 
@@ -60,6 +60,7 @@ namespace ApplyToBecomeInternal.Tests.Pages
 				{
 					return $"#{name}";
 				}
+
 				return $"#{name}-{position}";
 			}
 		}
@@ -80,5 +81,10 @@ namespace ApplyToBecomeInternal.Tests.Pages
 		}
 
 		public IDocument Document => _browsingContext.Active;
+
+		public void Dispose()
+		{
+			_factory.Reset();
+		}
 	}
 }


### PR DESCRIPTION
Tests were often flakey due to test data being shared across integration tests in the same class unintentionally. This was due to each test class sharing the same server, but not resetting it between tests.

This change _should_ fix that by implementing `IDisposable` on the `BaseIntegrationTests` class triggering a reset of the server every test.

