### PR TITLE
Remove unused Terraform variables

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,8 +21,6 @@ resource cloudfoundry_app worker_app {
 		"ASPNETCORE_URLS"          = "http://+:8080"
 		"TramsApi__Endpoint"       = var.app_trams_api_endpoint
 		"TramsApi__ApiKey"         = var.app_trams_api_key
-		"Authentication__Username" = var.app_username
-		"Authentication__Password" = var.app_password
 		"GoogleAnalytics__Enable"  = var.enable_google_analytics
 		"FeedbackLink"             = var.app_feedback_link
 		"SupportEmail"             = var.app_support_email


### PR DESCRIPTION
These are left-over from the previous authentication implementation and can now be removed.