### PR TITLE
Map landing page to `/project-list`

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Startup.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Startup.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json.Linq;
 using StackExchange.Redis;
 using System;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace ApplyToBecomeInternal
 {
@@ -139,6 +140,11 @@ namespace ApplyToBecomeInternal
 
 			app.UseEndpoints(endpoints =>
 			{
+				endpoints.MapGet("/", context =>
+				{
+					context.Response.Redirect("project-list", false);
+					return Task.CompletedTask;
+				});
 				endpoints.MapRazorPages();
 				endpoints.MapControllerRoute("default", "{controller}/{action}/");
 			});


### PR DESCRIPTION
Currently, we don't have a landing page, so we see the 404 not found page when visiting the base url. This is affecting the sign in redirect.

It probably makes sense to map the landing page to the `/project-list` page for now.