### PR TITLE
Update Cypress instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,26 @@ Install cypress and dependencies:
 - Run 'npm install' from the ApplyToBecomeCypressTests directory
 
 ### Test execution
-The Cypress tests will run against the front-end of the application, so the credentials you provide below should be of the user that is set up to run against the UI.
+You will need to set a secret in `secrets.json` in the following format to run the Cypress command against (you can use any value):
+
+```json
+{
+  "AzureAd": {
+    "ClientSecret": "<SECRET HERE>"
+  }
+}
+```
 
 To execute the tests locally and view the output, run the following:
 
 ```
-npm run cy:open -- --env username='USERNAME',password='PASSWORD',url="BASE_URL_OF_APP"
+npm run cy:open -- --env url="BASE_URL_OF_APP",authorizationHeader="<SECRET HERE>"
 ```
 
 To execute the tests in headless mode, run the following (the output will log to the console):
 
 ```
-npm run cy:run -- --env username='USERNAME',password='PASSWORD',url="BASE_URL_OF_APP"
+npm run cy:run -- --env url="BASE_URL_OF_APP",authorizationHeader="<SECRET HERE>"
 ```
 
 ### Useful tips


### PR DESCRIPTION
The authentication mechanism has changed for Cypress tests. Update the README with the new instructions.