### PR TITLE
Set Azure AD client secret in deploy to environment workflow

### DIFF
--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -143,6 +143,7 @@ jobs:
           TF_VAR_app_support_email: ${{ secrets.SUPPORT_EMAIL }}
           TF_VAR_enable_google_analytics: Yes
           TF_VAR_logit_sink_url: ${{ secrets.LOGIT_SINK_URL }}
+          TF_VAR_app_azuread_clientsecret: ${{ secrets.AZUREAD_CLIENTSECRET }}
 
   cypress-tests:
     needs: deploy-image


### PR DESCRIPTION
We are seeing the error `input variable "app_azuread_clientsecret" is not set` when running the deploy to environment workflow.