### PR TITLE
Update information source from TRAMS to Ofsted

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/SchoolPerformance/AdditionalInformation.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/SchoolPerformance/AdditionalInformation.cshtml
@@ -20,7 +20,7 @@
 		<span class="govuk-caption-l">@Model.Project.SchoolName</span>
 		<h1 class="govuk-heading-l">School performance (Ofsted information)</h1>
 		<div class="govuk-body">
-			<p class="govuk-body">This information comes from TRAMS. The table will go into your project template.</p>
+			<p class="govuk-body">This information comes from Ofsted. The table will go into your project template.</p>
 			<p class="govuk-body">You can add <a href="#additional-information">additional information</a> if you need to, this will also go into your project template.</p>
 			<p class="govuk-body-s">TRAMS last updated on: 23 March 2021</p><br>
 		</div>


### PR DESCRIPTION
We include some content about the source of the Ofsted information so that users have peace of mind.

While the data does come from TRAMS, it is uploaded from Ofsted, so we feel this might be more accurate. 