### PR TITLE
Suppress view override warnings

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/ApplyToBecomeInternal.csproj
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/ApplyToBecomeInternal.csproj
@@ -1,9 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<UserSecretsId>eae6d8bd-2a58-4ed4-99e2-a82f32b0ce47</UserSecretsId>
   	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	  <NoWarn>0436</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	  <NoWarn>0436</NoWarn>
+	</PropertyGroup>
 
 	<ItemGroup>
 	  <None Remove="Resources\htb-template.docx" />


### PR DESCRIPTION
We override the MicrosoftIdentity access-denied view in order to provide a custom message.

Unfortunately, we now see the warning `The type 'Areas_MicrosoftIdentity_Pages_Account_AccessDenied' conflicts with the imported type`. It seems as though this is expected and the only choices we have are to ignore it, or supress the warning, so choosing to suppress.