### PR TITLE
AB#102119 record decision - change on submit redirect page

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/TaskList/Decision/SummaryIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/TaskList/Decision/SummaryIntegrationTests.cs
@@ -191,12 +191,12 @@ namespace ApplyToBecomeInternal.Tests.Pages.TaskList.Decision
 		}
 
 		[Theory]
-		[InlineData(0, "Record the decision")]
-		[InlineData(1, "Who made this decision?")]
-		[InlineData(2, "Were any conditions set?")]
-		[InlineData(3, "What conditions were set?")]
-		[InlineData(4, "Date conversion was approved")]
-		public async Task Should_go_back_to_choose_and_submit_back_to_summary(int changeLinkIndex, string expectedTitle)
+		[InlineData(0, "Record the decision", "Who made this decision?")]
+		[InlineData(1, "Who made this decision?", "Were any conditions set?")]
+		[InlineData(2, "Were any conditions set?", "What conditions were set?")]
+		[InlineData(3, "What conditions were set?", "Date conversion was approved")]
+		[InlineData(4, "Date conversion was approved", "Check your answers before recording this decision")]
+		public async Task Should_go_back_to_choose_and_submit_back_to_summary(int changeLinkIndex, string changePageTitle, string nextPageTitle)
 		{
 			var request = new AdvisoryBoardDecision
 			{
@@ -216,12 +216,12 @@ namespace ApplyToBecomeInternal.Tests.Pages.TaskList.Decision
 			// Back to form
 			await NavigateAsync("Change", changeLinkIndex);
 
-			Document.QuerySelector<IHtmlElement>("h1").Text().Should().Be(expectedTitle);
+			Document.QuerySelector<IHtmlElement>("h1").Text().Should().Be(changePageTitle);
 
 			// submit form
 			await Document.QuerySelector<IHtmlButtonElement>("#submit-btn").SubmitAsync();
 
-			Document.QuerySelector<IHtmlElement>("h1").Text().Should().Be("Check your answers before recording this decision");
+			Document.QuerySelector<IHtmlElement>("h1").Text().Should().Be(nextPageTitle);
 		}		
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/AnyConditions.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/AnyConditions.cshtml.cs
@@ -33,7 +33,7 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			return Page();
 		}
 
-		public async Task<IActionResult> OnPostAsync(int id, [FromQuery(Name = "obl")] bool overideBackLink)
+		public async Task<IActionResult> OnPostAsync(int id)
 		{
 			if (!ModelState.IsValid)
 			{
@@ -47,8 +47,6 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			ClearConditionDetailsIfAppropriate(decision);
 
 			SetDecisionInSession(id, decision);
-
-			if (overideBackLink) return RedirectToPage(Links.Decision.Summary.Page, new { id });
 
 			return RedirectToPage(GetRedirectPageName(), new { id });
 		}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/RecordDecision.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/RecordDecision.cshtml.cs
@@ -32,7 +32,7 @@ namespace ApplyToBecomeInternal.Pages.Decision
 			return Page();
 		}
 
-		public async Task<IActionResult> OnPostAsync(int id, [FromQuery(Name = "obl")] bool overideBackLink)
+		public async Task<IActionResult> OnPostAsync(int id)
 		{
 			if (!ModelState.IsValid)
 			{
@@ -43,8 +43,6 @@ namespace ApplyToBecomeInternal.Pages.Decision
 			var decision = GetDecisionFromSession(id) ?? new AdvisoryBoardDecision();
 			decision.Decision = AdvisoryBoardDecision.Value;
 			SetDecisionInSession(id, decision);
-
-			if (overideBackLink) return RedirectToPage(Links.Decision.Summary.Page, new { id });
 
 			return RedirectToPage(Links.Decision.WhoDecided.Page, new { id });
 		}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/WhatConditions.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/WhatConditions.cshtml.cs
@@ -31,7 +31,7 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			return Page();
 		}
 
-		public async Task<IActionResult> OnPostAsync(int id, [FromQuery(Name = "obl")] bool overideBackLink)
+		public async Task<IActionResult> OnPostAsync(int id)
 		{
 			if (!ModelState.IsValid)
 			{
@@ -43,8 +43,6 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			decision.ApprovedConditionsDetails = ApprovedConditionsDetails;
 
 			SetDecisionInSession(id, decision);
-
-			if (overideBackLink) return RedirectToPage(Links.Decision.Summary.Page, new { id });
 
 			return RedirectToPage(Links.Decision.ApprovalDate.Page, new { id });
 		}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/WhoDecided.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/WhoDecided.cshtml.cs
@@ -38,7 +38,7 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			return Page();
 		}
 
-		public async Task<IActionResult> OnPostAsync(int id, [FromQuery(Name = "obl")] bool overideBackLink)
+		public async Task<IActionResult> OnPostAsync(int id)
 		{
 			if (!ModelState.IsValid)
 			{
@@ -50,8 +50,6 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			decision.DecisionMadeBy = DecisionMadeBy;
 
 			SetDecisionInSession(id, decision);
-
-			if (overideBackLink) return RedirectToPage(Links.Decision.Summary.Page, new { id });
 
 			return RedirectToPage(Links.Decision.AnyConditions.Page, new { id });
 		}


### PR DESCRIPTION
Addressing issue raised by @Lisa-V-Sau -

On the summary page, if the answer for 'were any conditions set' is 'No', and is then changed to 'Yes', the follow up question is not presented, hence it will always return empty on the summary page, and clicking 'record a decision' will return a bad request.

As as quick temporary solution; we have agreed that when changing a conditional question, the user will then be required to resubmit all answers from that point onwards this will also include re-entering 'date of decision'. 

We understand that it would be optimal to avoid to have the user re-visit questions that have already been answered which can be jarring, so another ticket will be added to the backlog tackle this. 