### PR TITLE
104169/decline reasons shuffled

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/DeclineReason.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/DeclineReason.cshtml.cs
@@ -51,11 +51,11 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 
 			var reasons = DeclinedReasons.Select(r => Enum.Parse<AdvisoryBoardDeclinedReasons>(r));
 			decision.DeclinedReasons.Clear();
-			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.Other));
 			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.Finance));
-			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.Governance));
 			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.Performance));
+			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.Governance));
 			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.ChoiceOfTrust));
+			AddReason(decision.DeclinedReasons, MapReason(reasons, AdvisoryBoardDeclinedReasons.Other));
 
 			EnsureExplanationIsProvidedFor(AdvisoryBoardDeclinedReasons.Finance, DeclineFinanceReason);
 			EnsureExplanationIsProvidedFor(AdvisoryBoardDeclinedReasons.Performance, DeclinePerformanceReason);


### PR DESCRIPTION
Changed the order in which the decline reasons are collected so that they are displayed in the expected order.