### PR TITLE
Fix ID for error message linking from summary to problem form field.

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/integration/Record_Decision/103787_error-handling.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/integration/Record_Decision/103787_error-handling.js
@@ -48,7 +48,7 @@ describe('103787 Error handling', () => {
 
         // trigger validation
         cy.continueBtn().click()
-        cy.get('[id="DeclinedReasons-error-link "]').should('contain.text', 'Select at least one reason')
+        cy.get('[id="DeclinedReasonSet-error-link "]').should('contain.text', 'Select at least one reason')
 
         // check all boxes on form
         cy.declineFinancebox().click()

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/DeclineReason.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/TaskList/Decision/DeclineReason.cshtml.cs
@@ -55,7 +55,7 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			}
 			else
 			{
-				ModelState.AddModelError("DeclinedReasons", "Select at least one reason");
+				ModelState.AddModelError("DeclinedReasonSet", "Select at least one reason");
 			}
 
 			EnsureExplanationIsProvidedFor(AdvisoryBoardDeclinedReasons.Finance, DeclineFinanceReason);
@@ -100,13 +100,6 @@ namespace ApplyToBecomeInternal.Pages.TaskList.Decision
 			DeclinePerformanceReason = reasons.GetValueOrDefault(AdvisoryBoardDeclinedReasons.Performance);
 			DeclineGovernanceReason = reasons.GetValueOrDefault(AdvisoryBoardDeclinedReasons.Governance);
 			DeclineChoiceOfTrustReason = reasons.GetValueOrDefault(AdvisoryBoardDeclinedReasons.ChoiceOfTrust);
-		}
-
-		private void AddReason(List<AdvisoryBoardDeclinedReasonDetails> reasons, AdvisoryBoardDeclinedReasonDetails reason)
-		{
-			if (reason == null) return;
-
-			reasons.Add(reason);
 		}
 
 		private void EnsureExplanationIsProvidedFor(AdvisoryBoardDeclinedReasons reason, string explanation)


### PR DESCRIPTION
Fixes an ID that meant the error summary link didn't work on the declined reason page when nothing was selected.