### PR TITLE
Task 107115: Disable Video & Screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -455,7 +455,3 @@ $RECYCLE.BIN/
 
 # minified js
 *.min.js
-
-# Cypress
-/ApplyToBecomeCypressTests/cypress/*
-/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/screenshots/*

--- a/.gitignore
+++ b/.gitignore
@@ -455,3 +455,7 @@ $RECYCLE.BIN/
 
 # minified js
 *.min.js
+
+# Cypress
+/ApplyToBecomeCypressTests/cypress/*
+/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/screenshots/*

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress.json
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress.json
@@ -1,4 +1,5 @@
 {
-	"video": true,
+	"video": false,
+	"screenshots": false,
 	"retries": 2	
 }


### PR DESCRIPTION
- Disabling videos & screenshots from cypress.json
- Remove cypress .gitignore

NOTES:
- Attempt of running videoRecording=false via the command line did not work hence using this method.