### PR TITLE
Task 108859: Fix cypress tests which  are failing with tags

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/96066_TL_legal-requirements/105392_legal-requirements.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/96066_TL_legal-requirements/105392_legal-requirements.cy.js
@@ -1,13 +1,14 @@
 /// <reference types ='Cypress'/>
 
 // TO DO: Check Legal Requirement validation on first time use; check Empty tags.
+import legalRequirements from "../../pages/legalRequirement"
 
-const url = Cypress.env('url') + '/task-list/2054'
-
-describe('Legal Requirements', { tags: ['@dev', '@stage']}, () => {
+describe('Legal Requirements', { tags: '@dev'}, () => {
     beforeEach(() => {
-        cy.visit(url)
-        cy.get('[data-cy="select-tasklist-links-legalrequirements"]').click()
+        legalRequirements.selectProject().then(() =>{
+            cy.url()
+            cy.get('[data-cy="select-tasklist-links-legalrequirements"]').click()
+        })
     })
 
     it('TC01: Answer to Governing Body and changes current answer from Yes, No, Not Applicable ', () => {
@@ -95,20 +96,20 @@ describe('Legal Requirements', { tags: ['@dev', '@stage']}, () => {
     })
 
     it('TC05: Confirm Legal Requirements page check & marked complete', () => {
-        cy.visit(url)
-        cy.get('[data-cy="select-tasklist-legalrequirements-status"]')
-        .invoke('text')
-        .then((text) => {
-            if (text.includes('Completed')) {
-                return
-            }
-            else {
-                cy.visit(url)
-                cy.get('[data-cy="select-tasklist-links-legalrequirements"]').click()
-                cy.get('[data-cy="select-legal-summary-iscomplete"]').click()
-                cy.get('[data-cy="select-legal-summary-submitbutton"]').click()
-                cy.get('[data-cy="select-tasklist-legalrequirements-status"]').should('contain.text', 'Completed')
-            }
+        legalRequirements.selectProject().then(() => {
+            cy.get('[data-cy="select-tasklist-legalrequirements-status"]')
+            .invoke('text')
+            .then((text) => {
+                if (text.includes('Completed')) {
+                    return
+                }
+                else {
+                    cy.get('[data-cy="select-tasklist-links-legalrequirements"]').click()
+                    cy.get('[data-cy="select-legal-summary-iscomplete"]').click()
+                    cy.get('[data-cy="select-legal-summary-submitbutton"]').click()
+                    cy.get('[data-cy="select-tasklist-legalrequirements-status"]').should('contain.text', 'Completed')
+                }
+        })
         })
     })
 

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/96066_TL_legal-requirements/105392_legal-requirements.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/96066_TL_legal-requirements/105392_legal-requirements.cy.js
@@ -6,7 +6,6 @@ import legalRequirements from "../../pages/legalRequirement"
 describe('Legal Requirements', { tags: '@dev'}, () => {
     beforeEach(() => {
         legalRequirements.selectProject().then(() =>{
-            cy.url()
             cy.get('[data-cy="select-tasklist-links-legalrequirements"]').click()
         })
     })

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/pages/legalRequirement.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/pages/legalRequirement.js
@@ -1,0 +1,14 @@
+class legalRequirements {
+    selectProject() {
+        let url = Cypress.env('url');
+        cy.visit(url);
+        cy.get('[data-cy="select-projecttype-input-conversion"]').click();
+        cy.get('[data-cy="select-common-submitbutton"]').click();
+        cy.get('[id="school-name-0"]').click();
+        
+
+        return cy.url()
+    };
+}
+
+export default new legalRequirements();

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/pages/legalRequirement.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/pages/legalRequirement.js
@@ -5,9 +5,6 @@ class legalRequirements {
         cy.get('[data-cy="select-projecttype-input-conversion"]').click();
         cy.get('[data-cy="select-common-submitbutton"]').click();
         cy.get('[id="school-name-0"]').click();
-        
-
-        return cy.url()
     };
 }
 

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/pages/legalRequirement.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/pages/legalRequirement.js
@@ -5,6 +5,8 @@ class legalRequirements {
         cy.get('[data-cy="select-projecttype-input-conversion"]').click();
         cy.get('[data-cy="select-common-submitbutton"]').click();
         cy.get('[id="school-name-0"]').click();
+    
+        return cy.url()
     };
 }
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,16 @@ To execute the tests in headless mode, run the following (the output will log to
 npm run cy:run -- --env url="BASE_URL_OF_APP",authorizationHeader="<SECRET HERE>"
 ```
 
-To execute tests with grep tags:
+To execute tests with grep tags on dev:
 
 ```
-$ npm run cy:run -- --env grepTags=@dev,url="BASE_URL_OF_APP",authorizationHeader="<SECRET HERE>"
+$ npm run cy:run -- --env grepTags=@dev,grepTags=@stage,url="BASE_URL_OF_APP",authorizationHeader="<SECRET HERE>"
+```
+
+To execute tests with grep tags on stage:
+
+```
+$ npm run cy:run -- --env grepTags=@stage,url="BASE_URL_OF_APP",authorizationHeader="<SECRET HERE>"
 ```
 
 ### Loading users from Azure Active Directory
@@ -119,13 +125,13 @@ before(function () {
 
 Further details about Cypress can be found here: https://docs.cypress.io/api/table-of-contents
 
-To run tests with multiple tags:
+To run tests with multiple tags in a list:
 
 ```
-i.e., greTags=@dev+@stage
+i.e., greTags=@dev+@stage 
 ```
 
-To run tests including multiple tags independently:
+To run tests including multiple tags independently targeting individual tags:
 
 ```
 i.e., grepTags=@dev,grepTags=@stage


### PR DESCRIPTION
Fixed legal requirements tests which were failing:

1. Using page objects to locate project
2. Tests are directed to Dev only since the change-link tag is missing on staging

Updated:

- README on tags