### PR TITLE
107871 Fixing project list content alignment for Conversions

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/wwwroot/src/index.scss
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/wwwroot/src/index.scss
@@ -22,3 +22,27 @@ for details on configuring this project to bundle and minify static web assets. 
 	font-family: Arial, sans-serif !important;
 	font-weight: 400;
 }
+.app-\!-width-one-fifth {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 20% !important;
+	}
+}
+.app-\!-width-two-fifths {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 40% !important;
+	}
+}
+.app-\!-width-three-fifths {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 60% !important;
+	}
+}
+.app-\!-width-four-fifths {
+	width: 100% !important;
+	@include govuk-media-query($from: tablet) {
+		width: 80% !important;
+	}
+}


### PR DESCRIPTION
### Context
Fixing project list content alignment for Conversions

DevOps ticket: https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=107871

### Changes proposed in this pull request
- Fixing project list content alignment for Conversions to make the columns 60% + 40%

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### Before 
<img width="1045" alt="Screenshot 2022-10-12 at 11 28 02" src="https://user-images.githubusercontent.com/6421298/195327013-8401fc73-8a97-4a99-9718-5ea74fa7c2c4.png">


### After 
<img width="1039" alt="Screenshot 2022-10-12 at 12 06 38" src="https://user-images.githubusercontent.com/6421298/195327124-0922d852-bd46-4060-a6d2-0339b4fed8ed.png">

