### PR TITLE
Updated to load available statuses from the API

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecome.Data/Services/AcademyConversionProjectRepository.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data/Services/AcademyConversionProjectRepository.cs
@@ -68,7 +68,7 @@ namespace ApplyToBecome.Data.Services
 			HttpResponseMessage response = await _httpClient.GetAsync("v2/conversion-projects/statuses");
 
 			if (response.IsSuccessStatusCode is false)
-				return new ApiResponse<List<string>>(HttpStatusCode.NotFound, null);
+				return new ApiResponse<List<string>>(response.StatusCode, null);
 
 			return new ApiResponse<List<string>>(HttpStatusCode.OK, await response.Content.ReadFromJsonAsync<List<string>>());
 		}

--- a/ApplyToBecomeInternal/ApplyToBecome.Data/Services/AcademyConversionProjectRepository.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data/Services/AcademyConversionProjectRepository.cs
@@ -63,18 +63,14 @@ namespace ApplyToBecome.Data.Services
 			return new ApiResponse<AcademyConversionProject>(response.StatusCode, project);
 		}
 
-		public Task<ApiResponse<List<string>>> GetAvailableStatuses()
+		public async Task<ApiResponse<List<string>>> GetAvailableStatuses()
 		{
-			return Task.FromResult(new ApiResponse<List<string>>(HttpStatusCode.OK, new List<string>
-			{
-				"Converter Pre-AO (C)",
-				"Pre Advisory Board",
-				"Active",
-				"Approved",
-				"Approved with Conditions",
-				"Deferred",
-				"Declined"
-			}));
+			HttpResponseMessage response = await _httpClient.GetAsync("v2/conversion-projects/statuses");
+
+			if (response.IsSuccessStatusCode is false)
+				return new ApiResponse<List<string>>(HttpStatusCode.NotFound, null);
+
+			return new ApiResponse<List<string>>(HttpStatusCode.OK, await response.Content.ReadFromJsonAsync<List<string>>());
 		}
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/BaseIntegrationTests.MockData.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/BaseIntegrationTests.MockData.cs
@@ -37,6 +37,15 @@ namespace ApplyToBecomeInternal.Tests.Pages
 			return projects;
 		}
 
+		protected List<string> AddGetStatuses()
+		{
+			List<string> statuses = new List<string> { "Accepted", "Accepted with Conditions", "Deferred", "Declined" };
+
+			_factory.AddGetWithJsonResponse("/v2/conversion-projects/statuses", statuses);
+
+			return statuses;
+		}
+
 		public AcademyConversionProject AddGetProject(Action<AcademyConversionProject> postSetup = null)
 		{
 			var project = _fixture.Create<AcademyConversionProject>();

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/BasicTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/BasicTests.cs
@@ -13,6 +13,7 @@ namespace ApplyToBecomeInternal.Tests.Pages
 		[InlineData("/project-list")]
 		public async Task Should_be_success_result_on_get(string url)
 		{
+			AddGetStatuses();
 			AddGetProjects();
 
 			await OpenUrlAsync(url);

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/ProjectList/ProjectListFilteringIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/ProjectList/ProjectListFilteringIntegrationTests.cs
@@ -13,6 +13,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.ProjectList
 	public class ProjectListFilteringIntegrationTests : BaseIntegrationTests, IAsyncLifetime
 	{
 		private int _recordCount;
+		private List<string> _statuses;
 
 		public ProjectListFilteringIntegrationTests(IntegrationTestingWebApplicationFactory factory) : base(factory)
 		{
@@ -29,6 +30,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.ProjectList
 		{
 			_recordCount = 20;
 			AddGetProjects(recordCount: _recordCount);
+			_statuses = AddGetStatuses();
 
 			await OpenUrlAsync("/project-list");
 

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/ProjectList/ProjectListIntegrationTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Pages/ProjectList/ProjectListIntegrationTests.cs
@@ -16,6 +16,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.ProjectList
 		public async Task Should_display_list_of_projects_and_navigate_to_and_from_task_list()
 		{
 			var projects = AddGetProjects().ToList();
+			AddGetStatuses();
 
 			await OpenUrlAsync($"/project-list");
 			var firstProject = AddGetProject(p => p.Id = projects.First().Id);
@@ -44,8 +45,9 @@ namespace ApplyToBecomeInternal.Tests.Pages.ProjectList
 
 		[Fact]
 		public async Task Should_display_approved_after_recording_decision()
-		{						
-			var projects = AddGetProjects(p => p.ProjectStatus = "Approved");			
+		{
+			AddGetStatuses();
+			var projects = AddGetProjects(p => p.ProjectStatus = "Approved");
 
 			await OpenUrlAsync($"/project-list");
 
@@ -56,6 +58,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.ProjectList
 		[Fact]
 		public async Task Should_display_preadvisoryboard_by_default()
 		{
+			AddGetStatuses();
 			var projects = AddGetProjects().ToList();
 
 			await OpenUrlAsync($"/project-list");
@@ -67,6 +70,7 @@ namespace ApplyToBecomeInternal.Tests.Pages.ProjectList
 		[Fact]
 		public async Task Should_display_application_received_date_when_no_htb_date_set()
 		{
+			AddGetStatuses();
 			var projects = AddGetProjects(p => p.HeadTeacherBoardDate = null);
 
 			await OpenUrlAsync($"/project-list");

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/ProjectList/Index.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/ProjectList/Index.cshtml.cs
@@ -41,11 +41,6 @@ namespace ApplyToBecomeInternal.Pages.ProjectList
 		{
 			ApiResponse<ApiV2Wrapper<IEnumerable<AcademyConversionProject>>> response = await _repository.GetAllProjects(CurrentPage, _pageSize);
 
-			if (!response.Success)
-			{
-				// 500 maybe?
-			}
-
 			ApiResponse<List<string>> statusesResponse = await _repository.GetAvailableStatuses();
 			if (statusesResponse.Success) Filters.Available = statusesResponse.Body;
 


### PR DESCRIPTION
Updated `AcademyConversionProjectRepository` to load available statuses from the API rather than a hard-coded list.