### PR TITLE
Add sonarcloud scanning to build and test github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet-sonarscanner begin /k:"DFE-Digital_a2b-internal" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        dotnet-sonarscanner begin /k:"DFE-Digital_a2b-internal" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
         dotnet build ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-restore
         dotnet-coverage collect 'dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal' -f xml -o 'coverage.xml'
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -13,13 +14,34 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v1
+      with:
+        path: ~\sonar\cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+    - name: Install SonarCloud scanners
+      run: dotnet tool install --global dotnet-sonarscanner
+    - name: Install dotnet-coverage
+      run: dotnet tool install --global dotnet-coverage
     - name: Restore dependencies
       run: dotnet restore ApplyToBecomeInternal/ApplyToBecomeInternal.sln
-    - name: Build
-      run: dotnet build ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-restore
-    - name: Test
-      run: dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal
+    - name: Build, Test and Analyze
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        dotnet-sonarscanner begin /k:"DFE-Digital_a2b-internal" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+        dotnet build ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-restore
+        dotnet-coverage collect 'dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal' -f xml -o 'coverage.xml'
+        dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
Adds the sonarcloud scanning capability to pull requests to main when opened and updated.

- Build and test stages have been merged to enable scanning
- dotnet-coverage tool has been included and should pipe coverage results into sonarcloud from testing stage