### PR TITLE
Remove dotnet-coverage from test step to stop silent failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,5 +43,5 @@ jobs:
       run: |
         dotnet-sonarscanner begin /k:"DFE-Digital_a2b-internal" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
         dotnet build ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-restore
-        dotnet-coverage collect 'dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal' -f xml -o 'coverage.xml'
+        dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
Until we can figure out how to stop dotnet-coverage from suppressing test failures, removing from the sonar scanning