### PR TITLE
Updated tests to be consistent on dev and staging

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109473_filter-by-delivery-officer.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109473_filter-by-delivery-officer.cy.js
@@ -18,7 +18,7 @@ Cypress._.each(['ipad-2'], (viewport) => {
       });   
   
       it('TC02: should display all the Non assigned projects when Not Assigned option is selected', () => {
-        cy.get('[data-cy=asyncmethodbuildercore-start-not-assigned]').click();
+        cy.get('[class="govuk-checkboxes__input"]').first().click();
         cy.get('[data-cy=select-projectlist-filter-apply]').click();
         cy.get('[data-cy="select-projectlist-filter-count"]').should('contain', 'projects found');
         cy.get('[data-cy="select-projectlist-filter-count"]').should('not.contain', '0 projects found');
@@ -26,10 +26,10 @@ Cypress._.each(['ipad-2'], (viewport) => {
       });
   
       it('TC03: should display all the projects assigned to the DO when a particular DO name option is selected', () => {
-        cy.get('[data-cy=asyncmethodbuildercore-start-adrian-horan]').click();
+        cy.get('[class="govuk-checkboxes__input"]').eq(1).click();
         cy.get('[data-cy=select-projectlist-filter-apply]').click();
         cy.get('[data-cy="select-projectlist-filter-count"]').should('not.contain', '0 projects found');
-        cy.get('#delivery-officer-0').should('have.text', 'Delivery officer: Adrian Horan');
+        cy.get('#delivery-officer-0').should('not.have.text', 'Delivery officer: Empty');
       });
     });
   });

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109901_project-count-format.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109901_project-count-format.cy.js
@@ -13,7 +13,7 @@ Cypress._.each(['ipad-2'], (viewport) => {
       });
   
       it('TC01: results should display correct format after applying filter', () => {
-        cy.get('[data-cy=asyncmethodbuildercore-start-not-assigned]').click();
+        cy.get('[class="govuk-checkboxes__input"]').first().click();
         cy.get('[data-cy=select-projectlist-filter-apply]').click();
         cy.get('[id="govuk-notification-banner-title"]')
           .should('contain', 'Success')
@@ -29,7 +29,7 @@ Cypress._.each(['ipad-2'], (viewport) => {
       });
 
       it('TC03: should display count when match found in the results on applying filter', () => {
-        cy.get('[data-cy="asyncmethodbuildercore-start-deferred"]').click();
+        cy.get('[class="govuk-checkboxes__input"]').eq(1).click();
         cy.get('[data-cy=select-projectlist-filter-apply]').click();
         cy.get('[data-cy="select-projectlist-filter-row"]')
         cy.get('[data-cy="select-projectlist-filter-count"]')


### PR DESCRIPTION
This PR uses the class instead of hardcoded cypress selectors to avoid them failing on staging as on staging we have a separate set of data.
<img width="668" alt="fix filters for staging" src="https://user-images.githubusercontent.com/116153732/201373190-984ecaf0-8d30-47ff-a196-29800589f54f.png">

<img width="763" alt="fix for staging" src="https://user-images.githubusercontent.com/116153732/201373222-854f87a2-195b-46b6-984b-d5c55e004987.png">
