### PR TITLE
Rollback dot net 6

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -2,7 +2,7 @@ name: Test, build, and deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, rollback-dot-net-6 ]
 
 env:
   REGISTRY: ghcr.io
@@ -149,18 +149,18 @@ jobs:
           TF_VAR_app_azuread_groupid: ${{ secrets.AZUREAD_GROUPID }}
           TF_VAR_app_cypresstest_secret : ${{ secrets.CYPRESS_TEST_SECRET }}
 
-  create-tag:    
+  create-tag:
     needs: deploy-image
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@v2
-      - name: Create tag string          
-        run: echo "RELEASE_TAGNAME=dev-`date +%Y-%m-%d`.${{ github.run_number }}" >> $GITHUB_ENV    
+      - name: Create tag string
+        run: echo "RELEASE_TAGNAME=dev-`date +%Y-%m-%d`.${{ github.run_number }}" >> $GITHUB_ENV
       - name: Create git tag
         run: |
           git tag ${{ env.RELEASE_TAGNAME }}
       - name: Push git tag
-        run: git push origin ${{ env.RELEASE_TAGNAME }}      
+        run: git push origin ${{ env.RELEASE_TAGNAME }}
 
   cypress-tests:
     needs: deploy-image
@@ -179,7 +179,7 @@ jobs:
         run: npm install
       - name: Run cypress
         run: npm run cy:run -- --env url='${{ secrets.ENDPOINT }}',authorizationHeader='${{ secrets.CYPRESS_TEST_SECRET }}'
-        env: 
+        env:
           db: ${{ secrets.DB_CONNECTION_STRING }}
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Public/CookiePreferences.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Public/CookiePreferences.cshtml
@@ -28,13 +28,17 @@
         <p class="govuk-body">
             Cookies are small files saved on your phone, tablet or computer when you visit a website.
         </p>
+
         <p class="govuk-body">
-            We use cookies to make this site work and to collect information about how you use our service.
+            We use cookies for the <a asp-page="@Links.ProjectList.Index.Page">conversions part of our Prepare conversions and transfers service.</a> We use them to make our service work and to collect information about how you use the service.
         </p>
 
         <p class="govuk-body">
-            With your permission, we use Google Analytics to collect data about how you use <a asp-page="@Links.ProjectList.Index.Page">the conversions part of our Prepare conversions and transfers service.</a> 
-            This information helps us improve our service.
+            There is a separate <a href="@Model.TransfersCookiesUrl">cookies page for the transfers part of this service.</a>
+        </p>
+
+        <p class="govuk-body">
+            With your permission, we use Google Analytics to collect data about how you use the service. This information helps us improve our service.
             These cookies do not collect your name or address, they do collect a unique user identifier
             code, which is linked to your device.
         </p>
@@ -112,7 +116,7 @@
                     <td class="govuk-table__cell">.AspNetCore.Antiforgery.9TtSrW0hzOs</td>
                     <td class="govuk-table__cell">Prevents forgery</td>
                     <td class="govuk-table__cell">1 hour</td>
-                </tr>                
+                </tr>
             </tbody>
         </table>
         <h3 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Public/CookiePreferences.cshtml.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Public/CookiePreferences.cshtml.cs
@@ -1,8 +1,10 @@
 using ApplyToBecomeInternal.Models;
+using ApplyToBecomeInternal.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 
 namespace ApplyToBecomeInternal.Pages.Public
@@ -14,15 +16,20 @@ namespace ApplyToBecomeInternal.Pages.Public
 		public bool PreferencesSet { get; set; } = false;
 		public string returnPath { get; set; }
 		private readonly ILogger<CookiePreferences> _logger;
+		private readonly IOptions<ServiceLinkOptions> _options;
 
-		public CookiePreferences(ILogger<CookiePreferences> logger)
+		public CookiePreferences(ILogger<CookiePreferences> logger, IOptions<ServiceLinkOptions> options)
 		{
 			_logger = logger;
+			_options = options;
 		}
+
+		public string TransfersCookiesUrl { get; set; }
 
 		public ActionResult OnGet(bool? consent, string returnUrl)
 		{
 			returnPath = returnUrl;
+			TransfersCookiesUrl = $"{_options.Value.TransfersUrl}/cookie-preferences?returnUrl=%2Fhome";
 
 			if (Request.Cookies.ContainsKey(ConsentCookieName))
 			{

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Shared/_CookieBanner.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Shared/_CookieBanner.cshtml
@@ -14,7 +14,7 @@
 				</p>
 				<div>
 					<a role="button" draggable="false" data-test="cookie-banner-accept" class="govuk-button govuk-!-margin-bottom-2" asp-page="@Links.Public.CookiePreferences.Page" asp-route-consent="true" asp-route-returnUrl="@Context.Request.Path">
-						Accept for the conversions part of this service
+						Accept cookies for the conversions part of this service
 					</a>
 					<p class="inline-message govuk-body">
 						or <a class="govuk-link" data-test="cookie-banner-link-2" asp-page="@Links.Public.CookiePreferences.Page" asp-route-returnUrl="@Context.Request.Path">set your cookie preferences</a>


### PR DESCRIPTION
Can't quickly find the reason one build passes while another fails which is blocking all progress, so undoing the update to .NET 6 pending the resolution of that problem.