### PR TITLE
Reverting updates to .NET 6.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.403
+        dotnet-version: 3.1.x
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
@@ -42,7 +42,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
         dotnet-sonarscanner begin /k:"DFE-Digital_a2b-internal" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
-        dotnet build ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-restore --configuration Release
-        dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
+        dotnet build ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-restore
+        dotnet test ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
         reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./ApplyToBecomeInternal/CoverageReport -reporttypes:SonarQube
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -12,13 +12,13 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.403
+          dotnet-version: 3.1.301
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
@@ -34,7 +34,7 @@ jobs:
         run: dotnet test -c Release ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal
   build-and-push-image:
     needs: test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -77,7 +77,7 @@ jobs:
 
   deploy-image:
     needs: build-and-push-image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: dev
     defaults:
       run:
@@ -149,23 +149,23 @@ jobs:
           TF_VAR_app_azuread_groupid: ${{ secrets.AZUREAD_GROUPID }}
           TF_VAR_app_cypresstest_secret : ${{ secrets.CYPRESS_TEST_SECRET }}
 
-  create-tag:
+  create-tag:    
     needs: deploy-image
-    runs-on: ubuntu-22.04
-    steps:
+    runs-on: ubuntu-latest
+    steps:      
       - uses: actions/checkout@v2
-      - name: Create tag string
-        run: echo "RELEASE_TAGNAME=dev-`date +%Y-%m-%d`.${{ github.run_number }}" >> $GITHUB_ENV
+      - name: Create tag string          
+        run: echo "RELEASE_TAGNAME=dev-`date +%Y-%m-%d`.${{ github.run_number }}" >> $GITHUB_ENV    
       - name: Create git tag
         run: |
           git tag ${{ env.RELEASE_TAGNAME }}
       - name: Push git tag
-        run: git push origin ${{ env.RELEASE_TAGNAME }}
+        run: git push origin ${{ env.RELEASE_TAGNAME }}      
 
   cypress-tests:
     needs: deploy-image
     environment: dev
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ApplyToBecomeInternal/ApplyToBecomeCypressTests
@@ -179,7 +179,7 @@ jobs:
         run: npm install
       - name: Run cypress
         run: npm run cy:run -- --env url='${{ secrets.ENDPOINT }}',authorizationHeader='${{ secrets.CYPRESS_TEST_SECRET }}'
-        env:
+        env: 
           db: ${{ secrets.DB_CONNECTION_STRING }}
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -15,13 +15,13 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.403
+          dotnet-version: 3.1.301
       - name: Setup node.js
         uses: actions/setup-node@v1
         with:
@@ -37,7 +37,7 @@ jobs:
         run: dotnet test -c Release ApplyToBecomeInternal/ApplyToBecomeInternal.sln --no-build --verbosity normal
   build-and-push-image:
     needs: test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -76,11 +76,11 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
           push: true
           build-args: |
-            COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}
+            COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}  
 
   deploy-image:
     needs: build-and-push-image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment}}
     defaults:
       run:
@@ -155,10 +155,10 @@ jobs:
 
   create-tag:
     needs: deploy-image
-    runs-on: ubuntu-22.04
-    steps:
+    runs-on: ubuntu-latest
+    steps:      
       - uses: actions/checkout@v2
-      - name: Create tag string
+      - name: Create tag string          
         run: echo "RELEASE_TAGNAME=${{ github.event.inputs.environment }}-`date +%Y-%m-%d`.${{ github.run_number }}" >> $GITHUB_ENV
       - name: Create git tag
         run: |
@@ -179,7 +179,7 @@ jobs:
     needs: deploy-image
     environment: staging
     if: ${{ github.event.inputs.environment}} == staging
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
          working-directory: ApplyToBecomeInternal/ApplyToBecomeCypressTests
@@ -193,7 +193,7 @@ jobs:
         run: npm install
       - name: Run cypress
         run: npm run cy:run -- --env url='${{ secrets.ENDPOINT }}',authorizationHeader='${{ secrets.CYPRESS_TEST_SECRET }}'
-        env:
+        env: 
           db: ${{ secrets.DB_CONNECTION_STRING }}
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/ApplyToBecomeInternal/ApplyToBecome.Data.Tests/ApplyToBecome.Data.Tests.csproj
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data.Tests/ApplyToBecome.Data.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
@@ -9,16 +9,16 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-		<PackageReference Include="FluentAssertions" Version="6.8.0" />
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
 		<PackageReference Include="MELT" Version="0.8.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
 		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.2.0">
+		<PackageReference Include="coverlet.collector" Version="1.3.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/ApplyToBecomeInternal/ApplyToBecome.Data.Tests/MoneyTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data.Tests/MoneyTests.cs
@@ -39,7 +39,7 @@ namespace ApplyToBecome.Data.Tests
 		public void ImplicitOperatorForAssignmentToString_WithDecimal_ReturnsMoneyWithValue(decimal input, string output)
 		{
 			var money = new Money(input);
-			money.ToString().Should().Be(output);
+			money.Should().Equals(output);
 		}
 	}
 }

--- a/ApplyToBecomeInternal/ApplyToBecome.Data.Tests/Services/AcademyConversionAdvisoryBoardDecisionRepositoryTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data.Tests/Services/AcademyConversionAdvisoryBoardDecisionRepositoryTests.cs
@@ -31,7 +31,7 @@ namespace ApplyToBecome.Data.Tests.Services
 		}
 
 		[Theory, AutoMoqData]
-		public async Task Should_throw_when_response_not_successful([Frozen] Mock<IHttpClientService> httpHelper,
+		public void Should_throw_when_response_not_successful([Frozen] Mock<IHttpClientService> httpHelper,
 			AcademyConversionAdvisoryBoardDecisionRepository sut,
 			AdvisoryBoardDecision decision)
 		{
@@ -40,8 +40,8 @@ namespace ApplyToBecome.Data.Tests.Services
 			m.Post<AdvisoryBoardDecision, AdvisoryBoardDecision>("/conversion-project/advisory-board-decision", decision))
 				.ReturnsAsync(new ApiResponse<AdvisoryBoardDecision>(responseCode, null));
 
-			await sut.Invoking(async s => await s.Create(decision))
-				.Should().ThrowAsync<Exception>().WithMessage($"Request to Api failed | StatusCode - {responseCode}");
+			sut.Invoking(async s => await s.Create(decision))
+				.Should().Throw<Exception>().WithMessage($"Request to Api failed | StatusCode - {responseCode}");
 		}
 
 	}

--- a/ApplyToBecomeInternal/ApplyToBecome.Data/ApplyToBecome.Data.csproj
+++ b/ApplyToBecomeInternal/ApplyToBecome.Data/ApplyToBecome.Data.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Azure.Identity" Version="1.8.0" />
-	  <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Graph" Version="4.47.0" />
+	  <PackageReference Include="Azure.Identity" Version="1.7.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.16" />
+	  <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+	  <PackageReference Include="Microsoft.Graph" Version="4.42.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-	  <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+	  <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/ApplyToBecomeInternal.Tests.csproj
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/ApplyToBecomeInternal.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,22 +11,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.17.1" />
-    <PackageReference Include="AngleSharp.Io" Version="0.17.0" />
+    <PackageReference Include="AngleSharp" Version="0.16.0" />
+    <PackageReference Include="AngleSharp.Io" Version="0.16.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.16" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="WireMock.Net" Version="1.5.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="WireMock.Net" Version="1.4.16" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ApplicationForm/Sections/AboutConversionSectionTests.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal.Tests/Models/ApplicationForm/Sections/AboutConversionSectionTests.cs
@@ -67,7 +67,7 @@ namespace ApplyToBecomeInternal.Tests.Models.ApplicationForm.Sections
 			sectionArray[0].Fields.Should().BeEquivalentTo(expectedFields);
 			sectionArray[1].Fields.Should().BeEquivalentTo(expectedFieldsContactDetails);
 			sectionArray[2].Fields.Should().BeEquivalentTo(expectedFieldsDateForConversion);
-			sectionArray[3].Fields.Should().ContainEquivalentOf(expectedFieldsReasonForJoining);
+			sectionArray[3].Fields.Should().BeEquivalentTo(expectedFieldsReasonForJoining);
 			sectionArray[4].Fields.Should().BeEquivalentTo(expectedFieldsNameChanges);
 		}
 
@@ -116,7 +116,7 @@ namespace ApplyToBecomeInternal.Tests.Models.ApplicationForm.Sections
 			sectionArray[0].Fields.Should().BeEquivalentTo(expectedFields);
 			sectionArray[1].Fields.Should().BeEquivalentTo(expectedFieldsContactDetails);
 			sectionArray[2].Fields.Should().BeEquivalentTo(expectedFieldsDateForConversion);
-			sectionArray[3].Fields.Should().ContainEquivalentOf(expectedFieldsReasonForJoining);
+			sectionArray[3].Fields.Should().BeEquivalentTo(expectedFieldsReasonForJoining);
 			sectionArray[4].Fields.Should().BeEquivalentTo(expectedFieldsNameChanges);
 		}
 
@@ -170,7 +170,7 @@ namespace ApplyToBecomeInternal.Tests.Models.ApplicationForm.Sections
 			sectionArray[0].Fields.Should().BeEquivalentTo(expectedFields);
 			sectionArray[1].Fields.Should().BeEquivalentTo(expectedFieldsContactDetails);
 			sectionArray[2].Fields.Should().BeEquivalentTo(expectedFieldsDateForConversion);
-			sectionArray[3].Fields.Should().ContainEquivalentOf(expectedFieldsReasonForJoining);
+			sectionArray[3].Fields.Should().BeEquivalentTo(expectedFieldsReasonForJoining);
 			sectionArray[4].Fields.Should().BeEquivalentTo(expectedFieldsNameChanges);
 		}
 	}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/ApplyToBecomeInternal.csproj
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/ApplyToBecomeInternal.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<UserSecretsId>eae6d8bd-2a58-4ed4-99e2-a82f32b0ce47</UserSecretsId>
   	</PropertyGroup>
 
@@ -23,19 +23,20 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AngleSharp" Version="0.17.1" />
-	  <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.Identity.Web" Version="1.25.6" />
-	  <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.25.6" />
-	  <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.17.0" />
-	  <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.17.0" />
-	  <PackageReference Include="Scrutor" Version="4.2.0" />
-	  <PackageReference Include="Sentry.AspNetCore" Version="3.23.1" />
-	  <PackageReference Include="Sentry.Serilog" Version="3.23.1" />
-	  <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
-	  <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+	  <PackageReference Include="AngleSharp" Version="0.16.0" />
+	  <PackageReference Include="DocumentFormat.OpenXml" Version="2.13.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.9" />
+	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.16" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
+	  <PackageReference Include="Microsoft.Identity.Web" Version="1.24.0" />
+	  <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.24.0" />
+	  <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.16.0" />
+	  <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.16.0" />
+	  <PackageReference Include="Scrutor" Version="3.3.0" />
+	  <PackageReference Include="Sentry.AspNetCore" Version="3.11.1" />
+	  <PackageReference Include="Sentry.Serilog" Version="3.11.1" />
+	  <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+	  <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Extensions/EnumerableExtensions.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ApplyToBecomeInternal.Extensions
+{
+	public static class EnumerableExtensions
+	{
+		public static IEnumerable<TSource> DistinctBy<TSource, TKey>
+			(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+		{
+			HashSet<TKey> seenKeys = new HashSet<TKey>();
+
+			return from TSource element in source
+				   where seenKeys.Add(keySelector(element))
+				   select element;
+		}
+	}
+}

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Startup.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Startup.cs
@@ -29,16 +29,18 @@ namespace ApplyToBecomeInternal
 {
 	public class Startup
 	{
-		public Startup(IConfiguration configuration)
+		public Startup(IConfiguration configuration, IWebHostEnvironment env)
 		{
 			Configuration = configuration;
+			_env = env;
 		}
 
 		public IConfiguration Configuration { get; }
+		private readonly IWebHostEnvironment _env;
 
 		public void ConfigureServices(IServiceCollection services)
 		{
-			services
+			var razorPages = services
 				.AddRazorPages(options =>
 				{
 					options.Conventions.AuthorizeFolder("/");
@@ -51,6 +53,11 @@ namespace ApplyToBecomeInternal
 			services.AddControllersWithViews()
 				.AddMicrosoftIdentityUI();
 		
+			if (_env.IsDevelopment())
+			{
+				razorPages.AddRazorRuntimeCompilation();
+			}
+
 			services.AddScoped(sp => sp.GetService<IHttpContextAccessor>()!.HttpContext.Session);
 			services.AddSession(options =>
 			{

--- a/ApplyToBecomeInternal/DocumentGeneration.Tests/DocumentGeneration.Tests.csproj
+++ b/ApplyToBecomeInternal/DocumentGeneration.Tests/DocumentGeneration.Tests.csproj
@@ -1,23 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Moq" Version="4.16.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ApplyToBecomeInternal/DocumentGeneration/DocumentGeneration.csproj
+++ b/ApplyToBecomeInternal/DocumentGeneration/DocumentGeneration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Reverts the update to .NET 6 to unblock all other work while we find and fix the reason the post-merge build workflow is breaking while all others pass.