### PR TITLE
Verify conversion cookies links and content

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86831_TL_cookies/112372_cookie-content.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86831_TL_cookies/112372_cookie-content.cy.js
@@ -1,0 +1,51 @@
+Cypress._.each(['ipad-mini'], (viewport) => {
+    describe(`112372: Cookie content details on Conversion on ${viewport}`, () => {
+      beforeEach(() => {
+        cy.viewport(viewport);
+        cy.login();
+      })
+  
+      afterEach(() => {
+        cy.clearCookies();
+      });
+  
+      it('TC01: should navigate to preference page when user click on collect information link', () => {
+        cy.get('[data-test="cookie-banner-link-1"]')
+          .should('have.text', 'collect information')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/cookie-preferences');
+        cy.get('h1').contains('Cookie preferences');  
+        });
+      });
+      
+      it('TC02: should navigate to preference page when user click on conversion part of our service link', () => {
+        cy.get('[data-test="cookie-banner-conversion-link"]')
+          .should('contain', 'conversions part of our service')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/cookie-preferences');
+        });
+      });
+
+      it('TC03: should navigate to preference page when user click on Accept cookies  link', () => {
+        cy.get('[data-test="cookie-banner-accept"]')
+          .should('contain', 'Accept cookies for the conversions part of this service')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/project-list');
+        cy.get('[data-cy="select-projectlist-filter-count"]');  
+        });
+      });
+
+      it('TC04: should navigate to preference page when user click on set your cookie preferences link', () => {
+        cy.get('[data-test="cookie-banner-link-2"]')
+          .should('have.text', 'set your cookie preferences')
+          .click();
+        cy.url().then(href => {
+          expect(href).includes('/cookie-preferences');
+        cy.get('h1').contains('Cookie preferences');  
+        });
+      });  
+    });
+});

--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Shared/_CookieBanner.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Shared/_CookieBanner.cshtml
@@ -10,7 +10,7 @@
 				<p class="govuk-body">
 					We use cookies to
 					<a class="govuk-link" data-test="cookie-banner-link-1" asp-page="@Links.Public.CookiePreferences.Page">collect information</a>
-					about how you use the <a asp-page="@Links.ProjectList.Index.Page">conversions part of our service.</a>
+					about how you use the <a asp-page="@Links.ProjectList.Index.Page" data-test="cookie-banner-conversion-link">conversions part of our service.</a>
 				</p>
 				<div>
 					<a role="button" draggable="false" data-test="cookie-banner-accept" class="govuk-button govuk-!-margin-bottom-2" asp-page="@Links.Public.CookiePreferences.Page" asp-route-consent="true" asp-route-returnUrl="@Context.Request.Path">


### PR DESCRIPTION
This PR covers the verification of Cookie links for Conversion, it's text as well as the redirection of the links.
Also added a selector to cshtml file (The related test will pass once the changes are merged to Dev env. )

<img width="572" alt="cookies conversions cypress" src="https://user-images.githubusercontent.com/116153732/202474186-fa0d7fe4-be83-4784-a57d-01f0875365b4.png">
