### PR TITLE
Fix DO filters issue

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109473_filter-by-delivery-officer.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109473_filter-by-delivery-officer.cy.js
@@ -18,7 +18,7 @@ Cypress._.each(['ipad-2'], (viewport) => {
       });   
   
       it('TC02: should display all the Non assigned projects when Not Assigned option is selected', () => {
-        cy.get('[class="govuk-checkboxes__input"]').first().click();
+        cy.get('[data-cy="select-projectlist-filter-officer-not-assigned"]').click();
         cy.get('[data-cy=select-projectlist-filter-apply]').click();
         cy.get('[data-cy="select-projectlist-filter-count"]').should('contain', 'projects found');
         cy.get('[data-cy="select-projectlist-filter-count"]').should('not.contain', '0 projects found');
@@ -26,7 +26,8 @@ Cypress._.each(['ipad-2'], (viewport) => {
       });
   
       it('TC03: should display all the projects assigned to the DO when a particular DO name option is selected', () => {
-        cy.get('[class="govuk-checkboxes__input"]').eq(1).click();
+        cy.get('[name="selectedOfficers"]').eq(1).click();
+       // cy.get('[class="govuk-checkboxes__input"]').eq(1).click();
         cy.get('[data-cy=select-projectlist-filter-apply]').click();
         cy.get('[data-cy="select-projectlist-filter-count"]').should('not.contain', '0 projects found');
         cy.get('#delivery-officer-0').should('not.have.text', 'Delivery officer: Empty');

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/support/commands.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/support/commands.js
@@ -546,6 +546,8 @@ Cypress.Commands.add('assignUser', () => {
 //Navigate To Filter Projects section
 Cypress.Commands.add('navigateToFilterProjects',() => {  
     cy.get('[data-cy="select-projectlist-filter-expand"]').click();
+    cy.get('[data-cy="select-projectlist-filter-clear"]').click();
+    cy.get('[data-cy="select-projectlist-filter-expand"]').click();
     cy.get('[data-id="filter-container"]').should('be.visible');
   });
 


### PR DESCRIPTION
The DO filters test case was failing due to selecting the project status filter as well as it looks like it was retaining the previous selected value . This PR is fixing the issue by giving the dedicated selector to DO as well as clearing the filters before applying the one to make test more robust.

![Annotation 2022-11-23 131516](https://user-images.githubusercontent.com/116153732/203556700-fda5cd4e-b762-4274-b9ba-3b8e74d62003.png)
