### PR TITLE
112115 Accessibility issue: record dates error message

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Shared/_ErrorSummary.cshtml
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Pages/Shared/_ErrorSummary.cshtml
@@ -1,30 +1,32 @@
 ﻿@inject ApplyToBecomeInternal.Services.ErrorService errorService
 @if (errorService.HasErrors() )
 { 
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-	<h2 class="govuk-error-summary__title" id="error-summary-title">
-		There is a problem
-	</h2>
-	<div class="govuk-error-summary__body">
-		<ul class="govuk-list govuk-error-summary__list" data-cy="error-summary">
-			@foreach (var error in errorService.GetErrors())
-			{
-				<li>
-					@if (error.Key?.Contains("/advisory-board-date") ?? false)
-					{
-						<a id="@($"{error.Key}-error-link")"  href=@error.Key>@error.Message</a>
-					}
-					else if (!string.IsNullOrWhiteSpace(error.Key))
-					{
-						<a  id="@($"{error.Key}-error-link")" href="#@error.Key">@error.Message</a>
-					}
-					else
-					{
-						<a id="@(error.Key)" href="#@(error.Key)">@error.Message</a>
-					}
-				</li>
-			}
-		</ul>
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" tabindex="-1" data-module="govuk-error-summary">
+	<div role="alert">
+		<h2 class="govuk-error-summary__title" id="error-summary-title">
+			There is a problem
+		</h2>
+		<div class="govuk-error-summary__body">
+			<ul class="govuk-list govuk-error-summary__list" data-cy="error-summary">
+				@foreach (var error in errorService.GetErrors())
+				{
+					<li>
+						@if (error.Key?.Contains("/advisory-board-date") ?? false)
+						{
+							<a id="@($"{error.Key}-error-link")"  href=@error.Key>@error.Message</a>
+						}
+						else if (!string.IsNullOrWhiteSpace(error.Key))
+						{
+							<a  id="@($"{error.Key}-error-link")" href="#@error.Key">@error.Message</a>
+						}
+						else
+						{
+							<a id="@(error.Key)" href="#@(error.Key)">@error.Message</a>
+						}
+					</li>
+				}
+			</ul>
+		</div>
 	</div>
 </div>
 }


### PR DESCRIPTION
### Context
Fixing accessibility issue: record dates error message not read aloud

DevOps ticket: https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_sprints/taskboard/Prepare%20conversions%20and%20transfers/Academies-and-Free-Schools-SIP/Manage%20an%20academy%20transfer/Sprint%2040?workitem=112115

### Changes proposed in this pull request
- fixing markup structure for error summary in Conversions

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally



