### PR TITLE
Disable x-xss protection

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/113646_disable-x-xss-protection/113746_disable_x-xss-protection.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/113646_disable-x-xss-protection/113746_disable_x-xss-protection.cy.js
@@ -1,0 +1,20 @@
+/// <reference types ='Cypress'/>
+
+Cypress._.each(['ipad-mini'], (viewport) => {
+	describe(`113746 X-xss-Protection Header on conversion ${viewport}`, () => {
+		beforeEach(() => {
+			cy.login()
+			cy.viewport(viewport)
+            
+		});
+		
+		it('TC01: should be disabled', () => {
+            cy.url().then(urlString => {
+			  let modifiedUrl = urlString
+              cy.request('GET', modifiedUrl).then((response) => {
+                expect(response.headers).to.have.property('x-xss-protection', '0')
+              });
+            });  
+		});
+    });
+});


### PR DESCRIPTION
This PR verifies if x-xss protect is disabled for conversion.
The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks.
<img width="1061" alt="conversion_ disable protection" src="https://user-images.githubusercontent.com/116153732/204766247-8a0a6f30-d17b-4381-982d-71b31c0e04e4.png">
