### PR TITLE
Run cypress tests in expected resolution

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84457_TL_school-and-trust-information-proj-dates/84596_error-handling_incorrect-url-tests.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84457_TL_school-and-trust-information-proj-dates/84596_error-handling_incorrect-url-tests.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`84596 Error handling should present correctly to the user on ${viewport}`, () => {
         after(function () {
             cy.clearLocalStorage()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84457_TL_school-and-trust-information-proj-dates/86296_error-handling_checkmark.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84457_TL_school-and-trust-information-proj-dates/86296_error-handling_checkmark.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86296 Check mark should reflect status correctly on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84457_TL_school-and-trust-information-proj-dates/86342_error-handling_error-routes.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84457_TL_school-and-trust-information-proj-dates/86342_error-handling_error-routes.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
 	describe(`86342 Error message link should redirect correctly on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.viewport(viewport)

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/86316_happy-path_mp-details.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/86316_happy-path_mp-details.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
 	describe(`86316 Submit and view MP details ${viewport}`, () => {
 		before(() => {
 			cy.viewport(viewport)

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/86858_modify-viability-field.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/86858_modify-viability-field.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86858 Modify viability fields on ${viewport}`, () => {
         afterEach(() => {
             cy.storeSessionData()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/86859_modify-financial-deficit.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/86859_modify-financial-deficit.cy.js
@@ -1,5 +1,5 @@
 /// <reference types ='Cypress'/>
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86859 Modify viability fields on ${viewport}`, () => {
         afterEach(() => {
             cy.storeSessionData()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/92796_modify_distance-from-school.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/84468_TL_general-Information/92796_modify_distance-from-school.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`92796 Modify Distance from School Info ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86338_error-404-checks_url-routing/86339_advisory-board-urls.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86338_error-404-checks_url-routing/86339_advisory-board-urls.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86339 validate advisory board urls on ${viewport}`, () => {
         let selectedSchool = ''
     

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86340_TL-record-dates-LA-information/86462_verify-date-sent-return.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86340_TL-record-dates-LA-information/86462_verify-date-sent-return.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
 	describe(`86462: "Date you sent/return the template" are reflected in preview on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86340_TL-record-dates-LA-information/86856_comments-updated-correctly.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86340_TL-record-dates-LA-information/86856_comments-updated-correctly.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86856 Comments should accept alphanumeric inputs on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86340_TL-record-dates-LA-information/87641_checkmark-application-status.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86340_TL-record-dates-LA-information/87641_checkmark-application-status.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`87641 Check mark should reflect status correctly on LA Information preview page on ${viewport}`, () =>{
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86826_TL_project-notes/86317_happy-path_project-notes.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86826_TL_project-notes/86317_happy-path_project-notes.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86317 Submit and view project notes on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86831_TL_cookies/86314_happy-path_cookie-consent-preferences.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86831_TL_cookies/86314_happy-path_cookie-consent-preferences.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
 	describe(`86314 Cookie consent details on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86862_TL_generate-project-template/86341_error-handling_advisory-board-date-errors.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/86862_TL_generate-project-template/86341_error-handling_advisory-board-date-errors.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
 	describe(`86341: Error messaging should be correct on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.viewport(viewport)

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/91521_SCAPP_apply-to-become/91489_Apply-to-become-get-application types.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/91521_SCAPP_apply-to-become/91489_Apply-to-become-get-application types.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['iphone-x'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
 	describe(`91489: Apply-to-become GET application types on ${viewport}`, () => {
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/assign-project/108871_assign-project.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/assign-project/108871_assign-project.cy.js
@@ -1,53 +1,53 @@
 /// <reference types ='Cypress'/>
 
+Cypress._.each(['ipad-mini'], (viewport) => {
+    describe('Assign project to user', () => {
 
-describe('Assign project to user', () => {
+        beforeEach(() => {
+            cy.selectFirstProject();
+        })
 
-    beforeEach(() => {
-        cy.selectFirstProject()
-    })
+        it('TC01: Assign a project to user for the first time', () => {
+            cy.unassignUser();
+            cy.get('a[href*="project-assignment"]').click();
+            cy.get('[id="delivery-officer"]').click().type('Richika Dogra').type('{enter}');
+            cy.get('[class="govuk-button"]').click();
+            cy.get('[id="notification-message"]').should('contain.text', 'Project is assigned');
+            cy.selectsConversion();
+            cy.get('[id="delivery-officer-0"]').should('contain.text', 'Richika Dogra');
+        });
 
-    it('TC01: Assign a project to user for the first time', () => {
-        cy.unassignUser()
-        cy.get('a[href*="project-assignment"]').click()
-        cy.get('[id="delivery-officer"]').click().type('Chris Sherlock').type('{enter}')
-        cy.get('[class="govuk-button"]').click()
-        cy.get('[id="notification-message"]').should('contain.text', 'Project is assigned')
-        cy.selectsConversion()
-        cy.get('[id="delivery-officer-0"]').should('contain.text', 'Chris Sherlock')
+        it('TC02: Remove assigned user by unassigning', () => {
+            cy.get('a[href*="project-assignment"]').click();
+            cy.get('[id="unassign-link"]').click();
+            cy.get('[id="notification-message"]').should('contain.text', 'Project is unassigned');
+        });
 
-    })
+        it('TC03: Remove assigned user via keyboard delete', () => {
+            cy.assignUser();
+            cy.get('a[href*="project-assignment"]').click();
+            cy.get('[id="delivery-officer"]').click().type('{backspace}');
+            cy.get('[class="govuk-button"]').click();
+        });
 
-    it('TC02: Remove assigned user by unassigning', () => {
-        cy.get('a[href*="project-assignment"]').click()
-        cy.get('[id="unassign-link"]').click()
-        cy.get('[id="notification-message"]').should('contain.text','Project is unassigned')
-    })
+        it('TC04: Click on the continue button while an assigned user is assigned', () => {
+            cy.assignUser();
+            cy.get('a[href*="project-assignment"]').click();
+            cy.get('[class="govuk-button"]').click();
+            cy.get('[id="notification-message"]').should('contain.text', 'Project is assigned');
+        });
 
-    it('TC03: Remove assigned user via keyboard delete', () => {
-        cy.assignUser()
-        cy.get('a[href*="project-assignment"]').click()
-        cy.get('[id="delivery-officer"]').click().type('{backspace}')
-        cy.get('[class="govuk-button"]').click()
-    })
+        it('TC05: Click on the unassigned button with no assigned user', () => {
+            cy.unassignUser();
+            cy.get('a[href*="project-assignment"]').click();
+            cy.get('[id="unassign-link"]');
+            cy.get('[class="govuk-button"]').click();
+        });
 
-    it('TC04: Click on the continue button while an assigned user is assigned', () => {
-        cy.assignUser()
-        cy.get('a[href*="project-assignment"]').click()
-        cy.get('[class="govuk-button"]').click()
-        cy.get('[id="notification-message"]').should('contain.text', 'Project is assigned')
-    })
-
-    it('TC05: Click on the unassigned button with no assigned user', () => {
-        cy.unassignUser()
-        cy.get('a[href*="project-assignment"]').click()
-        cy.get('[id="unassign-link"]')
-        cy.get('[class="govuk-button"]').click()
-    })
-
-    it('TC06: Project list is updated accordingly with unassigned', () => {
-        cy.unassignUser()
-        cy.selectsConversion()
-        cy.get('[id="delivery-officer-0"]').should('contain.text', 'Empty')
-    })
-})
+        it('TC06: Project list is updated accordingly with unassigned', () => {
+            cy.unassignUser();
+            cy.selectsConversion();
+            cy.get('[id="delivery-officer-0"]').should('contain.text', 'Empty')
+        });
+    });
+});    

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109473_filter-by-delivery-officer.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109473_filter-by-delivery-officer.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['ipad-2'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`109473: Filter projects by deliver officer ${viewport}`, () => {
       beforeEach(() => {
         cy.viewport(viewport);

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109901_project-count-format.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/conversion_filters/109901_project-count-format.cy.js
@@ -1,6 +1,6 @@
 /// <reference types ='Cypress'/>
 
-Cypress._.each(['ipad-2'], (viewport) => {
+Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`109473: Filter projects and verify the count ${viewport}`, () => {
       beforeEach(() => {
         cy.viewport(viewport);


### PR DESCRIPTION
Looks like the users of DfE app mostly use laptops or ipads based on the resolution 960px . And currently we are running most of the tests in iphone-x. Thus this PR comes into picture.
At first I was creating a Custom viewport however due to typescript error that wasn't possible until I use the typescript. 
Found a simple solution, to use `ipad-mini` as a viewport as it offers the same resolution of standard 960 px ( 1024, 768).
Also did some refactoring.
I have ran few updated tests and they are running fine. 
<img width="644" alt="run in correct resolution" src="https://user-images.githubusercontent.com/116153732/205101921-25987d75-a960-42c3-8264-504ec6429fb7.png">
