### PR TITLE
Fix tests for cypress 12 version

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Error-404-checks-url-routing/advisory-board-urls.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Error-404-checks-url-routing/advisory-board-urls.cy.js
@@ -3,10 +3,6 @@
 Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86339 validate advisory board urls on ${viewport}`, () => {
         let selectedSchool = ''
-    
-        afterEach(() => {
-            cy.storeSessionData()
-        });
 
 		beforeEach(() => {
 			cy.login()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Landing-page/landing-page.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Landing-page/landing-page.cy.js
@@ -8,10 +8,6 @@ describe('Landing Page', () => {
 
     })
 
-    afterEach(() => {
-        cy.storeSessionData()
-    })
-
     after(function () {
         cy.clearLocalStorage()
     })

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Pagination/home-page-pagination.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Pagination/home-page-pagination.cy.js
@@ -4,11 +4,7 @@ describe('101092: Pagination', () => {
 
 	beforeEach(() => {
 		cy.login()
-
 	})
-    afterEach(() => {
-        cy.storeSessionData()
-    })
 
     after(function () {
         cy.clearLocalStorage()

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/School-and-trust-information-proj-dates/error-handling-incorrect-url.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/School-and-trust-information-proj-dates/error-handling-incorrect-url.cy.js
@@ -6,10 +6,6 @@ Cypress._.each(['ipad-mini'], (viewport) => {
             cy.clearLocalStorage()
         });
     
-        afterEach(() => {
-            cy.storeSessionData()
-        });
-    
         beforeEach(() => {
             cy.login()
         });
@@ -27,7 +23,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
 
         })
     
-         it('TC01: Should open first school in the list', () => {
+        it('TC01: Should open first school in the list', () => {
             cy.viewport(viewport)
             cy.selectSchoolListing(0)
             cy.url().then(url => {

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Task-list-general-Information/modify-financial-deficit.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Task-list-general-Information/modify-financial-deficit.cy.js
@@ -1,10 +1,6 @@
 /// <reference types ='Cypress'/>
 Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86859 Modify viability fields on ${viewport}`, () => {
-        afterEach(() => {
-            cy.storeSessionData()
-        });
-
 		beforeEach(() => {
 			cy.login()
 			cy.selectSchoolListing(2)

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Task-list-general-Information/modify-viability-field.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/Task-list-general-Information/modify-viability-field.cy.js
@@ -2,10 +2,6 @@
 
 Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`86858 Modify viability fields on ${viewport}`, () => {
-        afterEach(() => {
-            cy.storeSessionData()
-        });
-
 		beforeEach(() => {
 			cy.login()
 			cy.selectSchoolListing(2)


### PR DESCRIPTION
Some of the Cypress test were failing due to the depreciation of a function in cypress version12.
Cookies, local storage and session storage in all domains are always cleared before setup runs, regardless of the testIsolation configuration.
Removed the sessionStorage wherever no needed.
![cypress_remove unwated function](https://user-images.githubusercontent.com/116153732/211313757-68c4c6bf-5bc3-4269-acaf-59b21409af6e.png)
![remove session storage](https://user-images.githubusercontent.com/116153732/211313785-417fa3dd-a01b-45c7-a647-f63803cb8ae8.png)
