### PR TITLE
Fix accessibility test and unskip

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/School-and-trust-information-proj-dates/error-handling-incorrect-url.cy.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/e2e/School-and-trust-information-proj-dates/error-handling-incorrect-url.cy.js
@@ -1,7 +1,12 @@
 /// <reference types ='Cypress'/>
+const axe = require("axe-core");
 
 Cypress._.each(['ipad-mini'], (viewport) => {
     describe(`84596 Error handling should present correctly to the user on ${viewport}`, () => {
+        const wcagStandards = [ "wcag22aa"];
+        const impactLevel = ["critical", "minor", "moderate", "serious"];
+        const continueOnFail = false;
+
         after(function () {
             cy.clearLocalStorage()
         });
@@ -14,14 +19,12 @@ Cypress._.each(['ipad-mini'], (viewport) => {
 			cy.viewport(viewport)
 		})
 
-        // Place holder for accessbility tests, to unskip once issues is resolved
-        it.skip('Accessbility', () => {
+       //accessibility check
+       it('Accessbility check', () => {
             let url = Cypress.env('url');
             cy.visit(url)
-            cy.injectAxe()
-            cy.checkA11y()
-
-        })
+            cy.excuteAccessibilityTests(wcagStandards, continueOnFail, impactLevel)
+        });
     
         it('TC01: Should open first school in the list', () => {
             cy.viewport(viewport)
@@ -47,14 +50,12 @@ Cypress._.each(['ipad-mini'], (viewport) => {
             cy.get('h1').should('not.contain.text','An unhandled exception occurred while processing the request.')
         });
         
-        // Raised under 81652
         it('TC03: Should display user-friendly error when incorrect project ID requested', () => {
             cy.viewport(viewport)
             cy.visit(Cypress.env('url') +'/task-list/9999', {failOnStatusCode: false})
             cy.get('[id="error-heading"]').should('have.text','Page not found')
         });
         
-        // Raised under 81655
         it('TC04: Should display user-friendly error when incorrect url requested', () => {
             cy.viewport(viewport)
             cy.visit(Cypress.env('url') +'/task-list-nonsense', {failOnStatusCode: false})

--- a/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/support/commands.js
+++ b/ApplyToBecomeInternal/ApplyToBecomeCypressTests/cypress/support/commands.js
@@ -582,3 +582,14 @@ Cypress.Commands.add('clearFilters', () => {
     cy.get('[data-cy="select-projectlist-filter-clear"]').should('have.text', 'Clear filters') 
   cy.get('[data-cy="select-projectlist-filter-clear"]').click();
 })
+
+Cypress.Commands.add('excuteAccessibilityTests', (wcagStandards, continueOnFail, impactLevel) => {
+    cy.injectAxe();
+    cy.checkA11y(null, {
+        runOnly: {
+            type: 'tag',
+            values: wcagStandards
+        },
+        includedImpacts: impactLevel
+    }, null, continueOnFail);
+})


### PR DESCRIPTION
This PR is to implement cypress accessibility and unskip the accessibility test.

Running accessibility testing as per WCAG. (wcag22aa)
There will be few more PR to cover accessibility testing in different pages
![accessibility test_cypress_first run](https://user-images.githubusercontent.com/116153732/212062365-6daae2d5-78b8-4cfd-9ab7-22a9b00f95fa.png)
