### PR TITLE
CSP: allow unsafe inline script from the Google Tag Manager URL

### DIFF
--- a/ApplyToBecomeInternal/ApplyToBecomeInternal/Security/SecureHeadersDefinitions.cs
+++ b/ApplyToBecomeInternal/ApplyToBecomeInternal/Security/SecureHeadersDefinitions.cs
@@ -39,8 +39,8 @@ namespace ApplyToBecomeInternal.Security
 					builder.AddFontSrc().Self();
 					builder.AddStyleSrc().Self();
 					builder.AddBaseUri().Self();
-					builder.AddScriptSrc().From(GoogleAnalyticsUri).UnsafeInline().WithNonce();
-					builder.AddFrameAncestors().None();
+					builder.AddScriptSrc().From(GoogleTagManagerUri).UnsafeInline().WithNonce();
+               builder.AddFrameAncestors().None();
 				})
 				.RemoveServerHeader()
 				.AddPermissionsPolicy(builder =>


### PR DESCRIPTION
This corrects which URL is allowed to provide (potentially) unsafe inline scripts to get Google Analytics working again. This reverts a change and brings this setting inline with Transfers.